### PR TITLE
AnalysisError feature, part 1.

### DIFF
--- a/openmdao/api.py
+++ b/openmdao/api.py
@@ -7,7 +7,7 @@ from openmdao.core.parallel_group import ParallelGroup
 from openmdao.core.explicitcomponent import ExplicitComponent
 from openmdao.core.implicitcomponent import ImplicitComponent
 from openmdao.core.indepvarcomp import IndepVarComp
-from openmdao.core.system import AnalysisError
+from openmdao.core.analysis_error import AnalysisError
 
 # Components
 from openmdao.components.deprecated_component import Component

--- a/openmdao/api.py
+++ b/openmdao/api.py
@@ -7,6 +7,7 @@ from openmdao.core.parallel_group import ParallelGroup
 from openmdao.core.explicitcomponent import ExplicitComponent
 from openmdao.core.implicitcomponent import ImplicitComponent
 from openmdao.core.indepvarcomp import IndepVarComp
+from openmdao.core.system import AnalysisError
 
 # Components
 from openmdao.components.deprecated_component import Component

--- a/openmdao/core/analysis_error.py
+++ b/openmdao/core/analysis_error.py
@@ -1,0 +1,14 @@
+"""
+OpenMDAO custom error: AnalysisError.
+"""
+
+
+class AnalysisError(Exception):
+    """
+    Analysis Error.
+
+    This exception indicates that a possibly recoverable numerical error occurred in an analysis
+    code or a subsolver.
+    """
+
+    pass

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -24,17 +24,6 @@ from openmdao.utils.units import convert_units
 from openmdao.utils.array_utils import convert_neg
 
 
-class AnalysisError(Exception):
-    """
-    Analysis Error.
-
-    This exception indicates that a possibly recoverable numerical error occurred in an analysis
-    code or a subsolver.
-    """
-
-    pass
-
-
 class System(object):
     """
     Base class for all systems in OpenMDAO.

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -24,6 +24,17 @@ from openmdao.utils.units import convert_units
 from openmdao.utils.array_utils import convert_neg
 
 
+class AnalysisError(Exception):
+    """
+    Analysis Error.
+
+    This exception indicates that a possibly recoverable numerical error occurred in an analysis
+    code or a subsolver.
+    """
+
+    pass
+
+
 class System(object):
     """
     Base class for all systems in OpenMDAO.

--- a/openmdao/docs/features/solvers/newton.rst
+++ b/openmdao/docs/features/solvers/newton.rst
@@ -78,6 +78,17 @@ Options
   .. embed-test::
       openmdao.solvers.nonlinear.tests.test_newton.TestNewtonFeatures.test_feature_max_sub_solves
 
+- err_on_maxiter
+
+  If you set this to True, then when the solver hits the iteration limit without meeting the tolerance criteria, it
+  will raise an AnalysisError exception. This is mainly important when coupled with a higher level solver or
+  driver (e.g., `pyOptSparseDriver`)that can handle the AnalysisError by adapting the stepsize and retrying.
+
+  .. embed-test::
+      openmdao.solvers.nonlinear.tests.test_newton.TestNewtonFeatures.test_feature_err_on_maxiter
+
+  This feature can be set on any iterative nonlinear or linear solver.
+
 Specifying a Linear Solver
 --------------------------
 

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -19,7 +19,7 @@ import scipy as sp
 from pyoptsparse import Optimization
 
 from openmdao.core.driver import Driver
-from openmdao.core.system import AnalysisError
+from openmdao.core.analysis_error import AnalysisError
 
 # names of optimizers that use gradients
 grad_drivers = {'CONMIN', 'FSQP', 'IPOPT', 'NLPQLP',

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -1052,10 +1052,11 @@ class TestPyoptSparse(unittest.TestCase):
         model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
 
         prob.driver = pyOptSparseDriver()
-        prob.driver.options['optimizer'] = OPTIMIZER
 
-        if OPTIMIZER == 'SLSQP':
-            prob.driver.opt_settings['ACC'] = 1e-9
+        # SNOPT has a weird cleanup problem when this fails, so we use SLSQP. For the
+        # regular failure, it doesn't matter which opt we choose since they all fail through.
+        prob.driver.options['optimizer'] = 'SLSQP'
+        prob.driver.opt_settings['ACC'] = 1e-9
 
         prob.driver.options['print_results'] = False
         model.add_design_var('x', lower=-50.0, upper=50.0)
@@ -1137,10 +1138,11 @@ class TestPyoptSparse(unittest.TestCase):
         model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
 
         prob.driver = pyOptSparseDriver()
-        prob.driver.options['optimizer'] = OPTIMIZER
 
-        if OPTIMIZER == 'SLSQP':
-            prob.driver.opt_settings['ACC'] = 1e-9
+        # SNOPT has a weird cleanup problem when this fails, so we use SLSQP. For the
+        # regular failure, it doesn't matter which opt we choose since they all fail through.
+        prob.driver.options['optimizer'] = 'SLSQP'
+        prob.driver.opt_settings['ACC'] = 1e-9
 
         prob.driver.options['print_results'] = False
         model.add_design_var('x', lower=-50.0, upper=50.0)

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -4,7 +4,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp, ExecComp
+from openmdao.api import Problem, Group, IndepVarComp, ExecComp, AnalysisError, ExplicitComponent
 from openmdao.devtools.testutil import assert_rel_error
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.expl_comp_array import TestExplCompArrayDense
@@ -18,6 +18,64 @@ OPT, OPTIMIZER = set_pyoptsparse_opt('SNOPT')
 
 if OPTIMIZER:
     from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
+
+
+class ParaboloidAE(ExplicitComponent):
+    """ Evaluates the equation f(x,y) = (x-3)^2 + xy + (y+4)^2 - 3
+    This version raises an analysis error 50% of the time.
+    The AE in ParaboloidAE stands for AnalysisError."""
+
+    def __init__(self):
+        super(ParaboloidAE, self).__init__()
+        self.fail_hard = False
+
+    def setup(self):
+        self.add_input('x', val=0.0)
+        self.add_input('y', val=0.0)
+
+        self.add_output('f_xy', val=0.0)
+
+        self.eval_iter_count = 0
+        self.eval_fail_at = 3
+
+        self.grad_iter_count = 0
+        self.grad_fail_at = 100
+
+    def compute(self, inputs, outputs):
+        """f(x,y) = (x-3)^2 + xy + (y+4)^2 - 3
+        Optimal solution (minimum): x = 6.6667; y = -7.3333
+        """
+        if self.eval_iter_count == self.eval_fail_at:
+            self.eval_iter_count = 0
+
+            if self.fail_hard:
+                raise RuntimeError('This should error.')
+            else:
+                raise AnalysisError('Try again.')
+
+        x = inputs['x']
+        y = inputs['y']
+
+        outputs['f_xy'] = (x-3.0)**2 + x*y + (y+4.0)**2 - 3.0
+        self.eval_iter_count += 1
+
+    def compute_partials(self, inputs, outputs, partials):
+        """ Jacobian for our paraboloid."""
+
+        if self.grad_iter_count == self.grad_fail_at:
+            self.grad_iter_count = 0
+
+            if self.fail_hard:
+                raise RuntimeError('This should error.')
+            else:
+                raise AnalysisError('Try again.')
+
+        x = inputs['x']
+        y = inputs['y']
+
+        partials['f_xy','x'] = 2.0*x - 6.0 + y
+        partials['f_xy','y'] = 2.0*y + 8.0 + x
+        self.grad_iter_count += 1
 
 
 class TestPyoptSparse(unittest.TestCase):
@@ -935,6 +993,173 @@ class TestPyoptSparse(unittest.TestCase):
         assert_rel_error(self, prob['z'][0], 1.9776, 1e-3)
         assert_rel_error(self, prob['z'][1], 0.0, 1e-3)
         assert_rel_error(self, prob['x'], 0.0, 1e-3)
+
+    def test_analysis_error_objfunc(self):
+
+        # Component raises an analysis error during some runs, and pyopt
+        # attempts to recover.
+
+        prob = Problem()
+        model = prob.model = Group()
+
+        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+
+        model.add_subsystem('comp', ParaboloidAE(), promotes=['*'])
+
+        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+
+        prob.driver = pyOptSparseDriver()
+        prob.driver.options['optimizer'] = OPTIMIZER
+
+        if OPTIMIZER == 'SLSQP':
+            prob.driver.opt_settings['ACC'] = 1e-9
+
+        prob.driver.options['print_results'] = False
+        model.add_design_var('x', lower=-50.0, upper=50.0)
+        model.add_design_var('y', lower=-50.0, upper=50.0)
+
+        model.add_objective('f_xy')
+        model.add_constraint('c', upper=-15.0)
+
+        prob.setup(check=False)
+        prob.run_driver()
+
+        # Minimum should be at (7.166667, -7.833334)
+        assert_rel_error(self, prob['x'], 7.16667, 1e-6)
+        assert_rel_error(self, prob['y'], -7.833334, 1e-6)
+
+        # Normally it takes 9 iterations, but takes 13 here because of the
+        # analysis failures. (note SLSQP takes 5 instead of 4)
+        if OPTIMIZER == 'SLSQP':
+            self.assertEqual(prob.driver.iter_count, 5)
+        else:
+            self.assertEqual(prob.driver.iter_count, 13)
+
+    def test_raised_error_objfunc(self):
+
+        # Component fails hard this time during execution, so we expect
+        # pyoptsparse to raise.
+
+        prob = Problem()
+        model = prob.model = Group()
+
+        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+
+        comp = model.add_subsystem('comp', ParaboloidAE(), promotes=['*'])
+
+        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+
+        prob.driver = pyOptSparseDriver()
+        prob.driver.options['optimizer'] = OPTIMIZER
+
+        if OPTIMIZER == 'SLSQP':
+            prob.driver.opt_settings['ACC'] = 1e-9
+
+        prob.driver.options['print_results'] = False
+        model.add_design_var('x', lower=-50.0, upper=50.0)
+        model.add_design_var('y', lower=-50.0, upper=50.0)
+
+        model.add_objective('f_xy')
+        model.add_constraint('c', upper=-15.0)
+
+        comp.fail_hard = True
+
+        prob.setup(check=False)
+
+        with self.assertRaises(Exception) as err:
+            prob.run_driver()
+
+        # pyopt's failure message differs by platform and is not informative anyway
+
+    def test_analysis_error_sensfunc(self):
+
+        # Component raises an analysis error during some linearize calls, and
+        # pyopt attempts to recover.
+
+        prob = Problem()
+        model = prob.model = Group()
+
+        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+
+        comp = model.add_subsystem('comp', ParaboloidAE(), promotes=['*'])
+
+        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+
+        prob.driver = pyOptSparseDriver()
+        prob.driver.options['optimizer'] = OPTIMIZER
+
+        if OPTIMIZER == 'SLSQP':
+            prob.driver.opt_settings['ACC'] = 1e-9
+
+        prob.driver.options['print_results'] = False
+        model.add_design_var('x', lower=-50.0, upper=50.0)
+        model.add_design_var('y', lower=-50.0, upper=50.0)
+
+        model.add_objective('f_xy')
+        model.add_constraint('c', upper=-15.0)
+
+        comp.grad_fail_at = 2
+        comp.eval_fail_at = 100
+
+        prob.setup(check=False)
+        prob.run_driver()
+
+        # SLSQP does a bad job recovering from gradient failures
+        if OPTIMIZER == 'SLSQP':
+            tol = 1e-2
+        else:
+            tol = 1e-6
+
+        # Minimum should be at (7.166667, -7.833334)
+        assert_rel_error(self, prob['x'], 7.16667, tol)
+        assert_rel_error(self, prob['y'], -7.833334, tol)
+
+        # Normally it takes 9 iterations, but takes 13 here because of the
+        # gradfunc failures. (note SLSQP just doesn't do well)
+        if OPTIMIZER == 'SNOPT':
+            self.assertEqual(prob.driver.iter_count, 13)
+
+    def test_raised_error_sensfunc(self):
+
+        # Component fails hard this time during gradient eval, so we expect
+        # pyoptsparse to raise.
+
+        prob = Problem()
+        model = prob.model = Group()
+
+        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+
+        comp = model.add_subsystem('comp', ParaboloidAE(), promotes=['*'])
+        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+
+        prob.driver = pyOptSparseDriver()
+        prob.driver.options['optimizer'] = OPTIMIZER
+
+        if OPTIMIZER == 'SLSQP':
+            prob.driver.opt_settings['ACC'] = 1e-9
+
+        prob.driver.options['print_results'] = False
+        model.add_design_var('x', lower=-50.0, upper=50.0)
+        model.add_design_var('y', lower=-50.0, upper=50.0)
+
+        model.add_objective('f_xy')
+        model.add_constraint('c', upper=-15.0)
+
+        comp.fail_hard = True
+        comp.grad_fail_at = 2
+        comp.eval_fail_at = 100
+
+        prob.setup(check=False)
+
+        with self.assertRaises(Exception) as err:
+            prob.run_driver()
+
+        # pyopt's failure message differs by platform and is not informative anyway
+        del prob
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/solvers/nonlinear/tests/test_newton.py
+++ b/openmdao/solvers/nonlinear/tests/test_newton.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from openmdao.api import Group, Problem, IndepVarComp, LinearBlockGS, \
     NewtonSolver, ExecComp, ScipyIterativeSolver, ImplicitComponent, \
-    DirectSolver, DenseJacobian
+    DirectSolver, DenseJacobian, AnalysisError
 from openmdao.devtools.testutil import assert_rel_error
 from openmdao.test_suite.components.double_sellar import DoubleSellar, DoubleSellarImplicit, \
      SubSellar
@@ -794,6 +794,25 @@ class TestNewton(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
+    def test_err_on_maxiter(self):
+        # Raise AnalysisError when it fails to converge
+
+        prob = Problem()
+        nlsolver = NewtonSolver()
+        prob.model = SellarDerivatives(nonlinear_solver=nlsolver, linear_solver=LinearBlockGS())
+
+        nlsolver.options['err_on_maxiter'] = True
+        nlsolver.options['maxiter'] = 1
+
+        prob.setup(check=False)
+        prob.set_solver_print(level=0)
+
+        with self.assertRaises(AnalysisError) as context:
+            prob.run_driver()
+
+        msg = "Solver 'NL: Newton' on system '' failed to converge."
+        self.assertEqual(str(context.exception), msg)
+
 
 class TestNewtonFeatures(unittest.TestCase):
 
@@ -979,6 +998,37 @@ class TestNewtonFeatures(unittest.TestCase):
 
         prob.setup()
         prob.run_model()
+
+    def test_feature_err_on_maxiter(self):
+
+        prob = Problem()
+        model = prob.model = Group()
+
+        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+
+        model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
+        model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
+
+        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                z=np.array([0.0, 0.0]), x=0.0),
+                            promotes=['obj', 'x', 'z', 'y1', 'y2'])
+
+        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+
+        model.linear_solver = LinearBlockGS()
+
+        nlgbs = model.nonlinear_solver = NewtonSolver()
+        nlgbs.options['maxiter'] = 1
+        nlgbs.options['err_on_maxiter'] = True
+
+        prob.setup()
+
+        try:
+            prob.run_model()
+        except AnalysisError:
+            pass
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -6,8 +6,10 @@ import os
 
 import numpy as np
 
-from openmdao.utils.options_dictionary import OptionsDictionary
+
+from openmdao.core.analysis_error import AnalysisError
 from openmdao.jacobians.assembled_jacobian import AssembledJacobian
+from openmdao.utils.options_dictionary import OptionsDictionary
 
 
 class SolverInfo(object):
@@ -82,6 +84,8 @@ class Solver(object):
                              desc='relative error tolerance')
         self.options.declare('iprint', type_=int, default=1,
                              desc='whether to print output')
+        self.options.declare('err_on_maxiter', type_=bool, default=False,
+                             desc="When True, AnlysisError will be raised if we don't convege.")
 
         # What the solver supports.
         self.supports = OptionsDictionary()
@@ -197,6 +201,12 @@ class Solver(object):
                 if iprint > -1:
                     msg = ' Failed to Converge in {} iterations'.format(self._iter_count)
                     print(self._solver_info.prefix + self.SOLVER + msg)
+
+                # Raise AnalysisError if requested.
+                if self.options['err_on_maxiter']:
+                    msg = "Solver '{}' on system '{}' failed to converge."
+                    raise AnalysisError(msg.format(self.SOLVER, self._system.pathname))
+
             elif iprint == 1:
                 print(self._solver_info.prefix + self.SOLVER +
                       ' Converged in {} iterations'.format(self._iter_count))


### PR DESCRIPTION
1. Analysis Error exception created; component-maker can use this to raise this special error.
2. The pyoptsparse driver catches the AnalysisError and allows pyoptsparse to try to evaluate another point for optimizers that support it (like SNOPT).
3. Any iterative solver can optionally raise an AnalysisError if it doesn't converged. This behavior is off by default.