### PR TITLE
Added a balance comp which is optionally vectorized.

### DIFF
--- a/openmdao/components/balance_comp.py
+++ b/openmdao/components/balance_comp.py
@@ -1,0 +1,230 @@
+"""Define the BalanceComp class."""
+
+from __future__ import print_function, division, absolute_import
+
+from numbers import Number
+from six import iteritems
+
+import numpy as np
+
+from openmdao.core.implicitcomponent import ImplicitComponent
+
+
+class BalanceComp(ImplicitComponent):
+    """
+    A simple equation balance for solving implicit equations.
+    """
+
+    def __init__(self, name=None, eq_units=None, **kwargs):
+        r"""
+        Initialize a BalanceComp, optionally creating a new implicit state variable.
+
+        The BalanceComp is a bit like IndepVarComp in that it allows for the
+        creation of one or more implicit state variables, and computes the residuals
+        for those variables based on the following equation.
+
+        .. math::
+
+          f_{mult}(x,...) \times f_{lhs}(x,...) = f_{rhs}(x,...)
+
+        Where :math:`f_{lhs}` represents the left-hand-side of the equation,
+        :math:`f_{lhs}` represents the right-hand-side, and :math:`f_{mult}`
+        is an optional multiplier on the left hand side.  At least one of these
+        quantities should be a function of the associated state variable.  If left
+        unconnected the multiplier is simply 1.0.
+
+        New state variables, and their associated residuals are created by
+        calling `add_balance`.  As an example, solving the equation
+        :math:`x**2 = 2` implicitly can be be accomplished as follows:
+
+        ::
+            prob = Problem(model=Group())
+
+            bal = BalanceComp()
+
+            bal.add_balance('x', val=1.0)
+
+            tgt = IndepVarComp(name='y_tgt', val=2)
+
+            exec_comp = ExecComp('y=x**2')
+
+            prob.model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
+
+            prob.model.add_subsystem(name='exec', subsys=exec_comp)
+
+            prob.model.add_subsystem(name='balance', subsys=bal)
+
+            prob.model.connect('y_tgt', 'balance.rhs:x')
+            prob.model.connect('balance.x', 'exec.x')
+            prob.model.connect('exec.y', 'balance.lhs:x')
+
+            prob.model.linear_solver = DirectSolver()
+            prob.model.nonlinear_solver = NewtonSolver()
+
+            prob.setup()
+
+            prob.run_model()
+
+        The arguments to add_balance can be provided on initialization to provide a balance
+        with a one state/residual without the need to call `add_output`:
+
+        ::
+            prob = Problem(model=Group())
+
+            bal = BalanceComp('x', val=1.0)
+
+            tgt = IndepVarComp(name='y_tgt', val=2)
+
+            exec_comp = ExecComp('y=x**2')
+
+            prob.model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
+
+            prob.model.add_subsystem(name='exec', subsys=exec_comp)
+
+            prob.model.add_subsystem(name='balance', subsys=bal)
+
+            prob.model.connect('y_tgt', 'balance.rhs:x')
+            prob.model.connect('balance.x', 'exec.x')
+            prob.model.connect('exec.y', 'balance.lhs:x')
+
+            prob.model.linear_solver = DirectSolver()
+            prob.model.nonlinear_solver = NewtonSolver()
+
+            prob.setup()
+
+            prob.run_model()
+
+
+        Parameters
+        ----------
+        name : str
+            The name of the state variable to be created.
+        eq_units : str or None
+            Units for the left-hand-side and right-hand-side of the equation to be balanced.
+        mult_val : int, float, or np.array
+            Default value for the LHS multiplier of the given state.  Must be compatible
+            with the shape (optionally) given by the val option in kwargs.
+        kwargs : dict
+            Additional arguments to be passed for the creation of the implicit state variable.
+        """
+        super(BalanceComp, self).__init__()
+        self._state_vars = {}
+        if name is not None:
+            self.add_balance(name, **kwargs)
+
+    def setup(self):
+        """
+        Define the independent variables, output variables, and partials.
+        """
+        self.declare_partials(of='*', wrt='*', dependent=False)
+
+        for name, options in iteritems(self._state_vars):
+
+            lhs_name = 'lhs:{0}'.format(name)
+            rhs_name = 'rhs:{0}'.format(name)
+            mult_name = 'mult:{0}'.format(name)
+
+            self._state_vars[name]['lhs_name'] = lhs_name
+            self._state_vars[name]['rhs_name'] = rhs_name
+            self._state_vars[name]['mult_name'] = mult_name
+
+            val = options['kwargs'].get('val', np.ones(1))
+            if isinstance(val, Number):
+                n = 1
+            else:
+                n = len(val)
+            self._state_vars[name]['size'] = n
+
+            self.add_output(name, **options['kwargs'])
+            self.add_input(lhs_name, val=np.ones(n), units=options['eq_units'])
+            self.add_input(rhs_name, val=np.ones(n), units=options['eq_units'])
+            self.add_input(mult_name, val=options['mult_val'] * np.ones(n), units=None)
+            self._scale_factor = np.ones(n)
+            self._dscale_drhs = np.ones(n)
+
+            arange = np.arange(n)
+
+            self.declare_partials(of=name, wrt=lhs_name, rows=arange, cols=arange, val=1.0)
+            self.declare_partials(of=name, wrt=rhs_name, rows=arange, cols=arange, val=1.0)
+            self.declare_partials(of=name, wrt=mult_name, rows=arange, cols=arange, val=1.0)
+
+    def apply_nonlinear(self, inputs, outputs, residuals):
+        """
+        Calculate the residual for each balance.
+        """
+        for name, options in iteritems(self._state_vars):
+            lhs_name = options['lhs_name']
+            rhs_name = options['rhs_name']
+            mult_name = options['mult_name']
+
+            lhs = inputs[lhs_name]
+            rhs = inputs[rhs_name]
+            mult = inputs[mult_name]
+
+            # Indices where the rhs is near zero or not near zero
+            idxs_nz = np.where(np.abs(rhs) < 2)[0]
+            idxs_nnz = np.where(np.abs(rhs) >= 2)[0]
+
+            # Compute scaling factors
+            # scale factor that normalizes by the rhs, except near 0
+            self._scale_factor[idxs_nnz] = 1.0 / np.abs(rhs[idxs_nnz])
+            self._scale_factor[idxs_nz] = 1.0 / (.25 * rhs[idxs_nz] ** 2 + 1)
+
+            residuals[name] = (mult * lhs - rhs) * self._scale_factor
+
+    def linearize(self, inputs, outputs, jacobian):
+        """
+        Calculate the partials of the residual for each balance.
+        """
+        for name, options in iteritems(self._state_vars):
+            lhs_name = options['lhs_name']
+            rhs_name = options['rhs_name']
+            mult_name = options['mult_name']
+
+            lhs = inputs[lhs_name]
+            rhs = inputs[rhs_name]
+            mult = inputs[mult_name]
+
+            # Indices where the rhs is near zero or not near zero
+            idxs_nz = np.where(np.abs(rhs) < 2)[0]
+            idxs_nnz = np.where(np.abs(rhs) >= 2)[0]
+
+            # scale factor that normalizes by the rhs, except near 0
+            self._scale_factor[idxs_nnz] = 1.0 / np.abs(rhs[idxs_nnz])
+            self._scale_factor[idxs_nz] = 1.0 / (.25 * rhs[idxs_nz] ** 2 + 1)
+
+            self._dscale_drhs[idxs_nnz] = np.sign(rhs[idxs_nnz]) / rhs[idxs_nnz]**2
+            self._dscale_drhs[idxs_nz] = -.5 * rhs[idxs_nz] / (.25 * rhs[idxs_nz] ** 2 + 1) ** 2
+
+            # Partials of residual wrt rhs
+            jacobian[name, rhs_name] = (mult * lhs - rhs) * self._dscale_drhs - self._scale_factor
+
+            # Partials of residual wrt lhs
+            jacobian[name, lhs_name] = mult * self._scale_factor
+
+            # Partials of residual wrt mult
+            jacobian[name, mult_name] = lhs * self._scale_factor
+
+    def add_balance(self, name, eq_units=None, mult_val=1.0, **kwargs):
+        """
+        Add a new state variable and associated equation to be balanced.
+
+        This will create new inputs `lhs:name`, `rhs:name`, and `mult:name` that will
+        define the left and right sides of the equation to be balanced, and a
+        multiplier for the left-hand-side.
+
+        Parameters
+        ----------
+        name : str
+            The name of the state variable to be created.
+        eq_units : str or None
+            Units for the left-hand-side and right-hand-side of the equation to be balanced.
+        mult_val : int, float, or np.array
+            Default value for the LHS multiplier.  Must be compatible with the shape (optionally)
+            given by the val option in kwargs.
+        kwargs : dict
+            Additional arguments to be passed for the creation of the implicit state variable.
+        """
+        self._state_vars[name] = {'kwargs': kwargs,
+                                  'eq_units': eq_units,
+                                  'mult_val': mult_val}

--- a/openmdao/components/balance_comp.py
+++ b/openmdao/components/balance_comp.py
@@ -28,7 +28,7 @@ class BalanceComp(ImplicitComponent):
           f_{mult}(x,...) \times f_{lhs}(x,...) = f_{rhs}(x,...)
 
         Where :math:`f_{lhs}` represents the left-hand-side of the equation,
-        :math:`f_{lhs}` represents the right-hand-side, and :math:`f_{mult}`
+        :math:`f_{rhs}` represents the right-hand-side, and :math:`f_{mult}`
         is an optional multiplier on the left hand side.  At least one of these
         quantities should be a function of the associated state variable.  If left
         unconnected the multiplier is simply 1.0.

--- a/openmdao/components/tests/test_balance_comp.py
+++ b/openmdao/components/tests/test_balance_comp.py
@@ -1,0 +1,379 @@
+from __future__ import print_function, division, absolute_import
+
+import os
+import unittest
+
+import numpy as np
+from numpy.testing import assert_almost_equal
+from openmdao.api import Problem, Group, IndepVarComp, ExecComp, \
+    NewtonSolver, DirectSolver, DenseJacobian
+from openmdao.components.balance_comp import BalanceComp
+
+
+class TestBalanceComp(unittest.TestCase):
+
+    def test_scalar_example(self):
+
+        prob = Problem(model=Group())
+
+        bal = BalanceComp()
+
+        bal.add_balance('x', val=1.0)
+
+        tgt = IndepVarComp(name='y_tgt', val=2)
+
+        exec_comp = ExecComp('y=x**2')
+
+        prob.model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
+
+        prob.model.add_subsystem(name='exec', subsys=exec_comp)
+
+        prob.model.add_subsystem(name='balance', subsys=bal)
+
+        prob.model.connect('y_tgt', 'balance.rhs:x')
+        prob.model.connect('balance.x', 'exec.x')
+        prob.model.connect('exec.y', 'balance.lhs:x')
+
+        prob.model.linear_solver = DirectSolver()
+        prob.model.nonlinear_solver = NewtonSolver()
+
+        prob.setup()
+
+        prob.run_model()
+
+        assert_almost_equal(prob['balance.x'], np.sqrt(2), decimal=7)
+
+        np.set_printoptions(linewidth=1024)
+
+        cpd = prob.check_partials()
+
+        for (of, wrt) in cpd['balance']:
+            assert_almost_equal(cpd['balance'][of, wrt]['abs error'], 0.0, decimal=5)
+
+    def test_create_on_init(self):
+
+        prob = Problem(model=Group())
+
+        bal = BalanceComp('x', val=1.0)
+
+        tgt = IndepVarComp(name='y_tgt', val=2)
+
+        exec_comp = ExecComp('y=x**2')
+
+        prob.model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
+
+        prob.model.add_subsystem(name='exec', subsys=exec_comp)
+
+        prob.model.add_subsystem(name='balance', subsys=bal)
+
+        prob.model.connect('y_tgt', 'balance.rhs:x')
+        prob.model.connect('balance.x', 'exec.x')
+        prob.model.connect('exec.y', 'balance.lhs:x')
+
+        prob.model.linear_solver = DirectSolver()
+        prob.model.nonlinear_solver = NewtonSolver()
+
+        prob.setup()
+
+        prob.run_model()
+
+        assert_almost_equal(prob['balance.x'], np.sqrt(2), decimal=7)
+
+        np.set_printoptions(linewidth=1024)
+
+        cpd = prob.check_partials()
+
+        for (of, wrt) in cpd['balance']:
+            assert_almost_equal(cpd['balance'][of, wrt]['abs error'], 0.0, decimal=5)
+
+
+    def test_vectorized(self):
+
+        n = 100
+
+        prob = Problem(model=Group())
+
+        bal = BalanceComp()
+
+        bal.add_balance('x', val=np.ones(n))
+
+        tgt = IndepVarComp(name='y_tgt', val=4*np.ones(n))
+
+        exec_comp = ExecComp('y=x**2', x={'value': np.ones(n)}, y={'value': np.ones(n)})
+
+        prob.model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
+
+        prob.model.add_subsystem(name='exec', subsys=exec_comp)
+
+        prob.model.add_subsystem(name='balance', subsys=bal)
+
+        prob.model.connect('y_tgt', 'balance.rhs:x')
+        prob.model.connect('balance.x', 'exec.x')
+        prob.model.connect('exec.y', 'balance.lhs:x')
+
+        prob.model.linear_solver = DirectSolver()
+
+        prob.model.nonlinear_solver = NewtonSolver()
+        prob.model.nonlinear_solver.options['maxiter'] = 100
+        prob.model.nonlinear_solver.options['iprint'] = 0
+
+        prob.model.jacobian = DenseJacobian()
+
+        prob.setup()
+
+        prob['balance.x'] = np.random.rand(n)
+
+        prob.run_model()
+
+        assert_almost_equal(prob['balance.x'], 2.0, decimal=7)
+
+        np.set_printoptions(linewidth=1024)
+
+        cpd = prob.check_partials()
+
+        for (of, wrt) in cpd['balance']:
+            assert_almost_equal(cpd['balance'][of, wrt]['abs error'], 0.0, decimal=5)
+
+    def test_vectorized_with_mult(self):
+
+        n = 100
+
+        prob = Problem(model=Group())
+
+        bal = BalanceComp()
+
+        bal.add_balance('x', val=np.ones(n))
+
+        tgt = IndepVarComp(name='y_tgt', val=4*np.ones(n))
+
+        mult_ivc = IndepVarComp(name='mult', val=2.0*np.ones(n))
+
+        exec_comp = ExecComp('y=x**2', x={'value': np.ones(n)}, y={'value': np.ones(n)})
+
+        prob.model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
+        prob.model.add_subsystem(name='mult_comp', subsys=mult_ivc, promotes_outputs=['mult'])
+
+        prob.model.add_subsystem(name='exec', subsys=exec_comp)
+
+        prob.model.add_subsystem(name='balance', subsys=bal)
+
+        prob.model.connect('y_tgt', 'balance.rhs:x')
+        prob.model.connect('mult', 'balance.mult:x')
+        prob.model.connect('balance.x', 'exec.x')
+        prob.model.connect('exec.y', 'balance.lhs:x')
+
+        prob.model.linear_solver = DirectSolver()
+
+        prob.model.nonlinear_solver = NewtonSolver()
+        prob.model.nonlinear_solver.options['maxiter'] = 100
+        prob.model.nonlinear_solver.options['iprint'] = 0
+
+        prob.model.jacobian = DenseJacobian()
+
+        prob.setup()
+
+        prob['balance.x'] = np.random.rand(n)
+
+        prob.run_model()
+
+        assert_almost_equal(prob['balance.x'], np.sqrt(2), decimal=7)
+
+        np.set_printoptions(linewidth=1024)
+
+        cpd = prob.check_partials()
+
+        for (of, wrt) in cpd['balance']:
+            assert_almost_equal(cpd['balance'][of, wrt]['abs error'], 0.0, decimal=5)
+
+    def test_vectorized_with_default_mult(self):
+
+        n = 100
+
+        prob = Problem(model=Group())
+
+        bal = BalanceComp()
+
+        bal.add_balance('x', val=np.ones(n), mult_val=2.0)
+
+        tgt = IndepVarComp(name='y_tgt', val=4 * np.ones(n))
+
+        exec_comp = ExecComp('y=x**2', x={'value': np.ones(n)}, y={'value': np.ones(n)})
+
+        prob.model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
+
+        prob.model.add_subsystem(name='exec', subsys=exec_comp)
+
+        prob.model.add_subsystem(name='balance', subsys=bal)
+
+        prob.model.connect('y_tgt', 'balance.rhs:x')
+        prob.model.connect('balance.x', 'exec.x')
+        prob.model.connect('exec.y', 'balance.lhs:x')
+
+        prob.model.linear_solver = DirectSolver()
+
+        prob.model.nonlinear_solver = NewtonSolver()
+        prob.model.nonlinear_solver.options['maxiter'] = 100
+        prob.model.nonlinear_solver.options['iprint'] = 0
+
+        prob.model.jacobian = DenseJacobian()
+
+        prob.setup()
+
+        prob['balance.x'] = np.random.rand(n)
+
+        prob.run_model()
+
+        assert_almost_equal(prob['balance.x'], np.sqrt(2), decimal=7)
+
+        np.set_printoptions(linewidth=1024)
+
+        cpd = prob.check_partials()
+
+        for (of, wrt) in cpd['balance']:
+            assert_almost_equal(cpd['balance'][of, wrt]['abs error'], 0.0, decimal=5)
+
+    def test_vectorized_with_default_mult(self):
+
+        n = 100
+
+        prob = Problem(model=Group())
+
+        bal = BalanceComp('x', val=np.ones(n), mult_val=2.0)
+
+        tgt = IndepVarComp(name='y_tgt', val=4 * np.ones(n))
+
+        exec_comp = ExecComp('y=x**2', x={'value': np.ones(n)}, y={'value': np.ones(n)})
+
+        prob.model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
+
+        prob.model.add_subsystem(name='exec', subsys=exec_comp)
+
+        prob.model.add_subsystem(name='balance', subsys=bal)
+
+        prob.model.connect('y_tgt', 'balance.rhs:x')
+        prob.model.connect('balance.x', 'exec.x')
+        prob.model.connect('exec.y', 'balance.lhs:x')
+
+        prob.model.linear_solver = DirectSolver()
+
+        prob.model.nonlinear_solver = NewtonSolver()
+        prob.model.nonlinear_solver.options['maxiter'] = 100
+        prob.model.nonlinear_solver.options['iprint'] = 0
+
+        prob.model.jacobian = DenseJacobian()
+
+        prob.setup()
+
+        prob['balance.x'] = np.random.rand(n)
+
+        prob.run_model()
+
+        assert_almost_equal(prob['balance.x'], np.sqrt(2), decimal=7)
+
+        np.set_printoptions(linewidth=1024)
+
+        cpd = prob.check_partials()
+
+        for (of, wrt) in cpd['balance']:
+            assert_almost_equal(cpd['balance'][of, wrt]['abs error'], 0.0, decimal=5)
+
+    def test_scalar(self):
+
+        n = 1
+
+        prob = Problem(model=Group())
+
+        bal = BalanceComp()
+
+        bal.add_balance('x')
+
+        tgt = IndepVarComp(name='y_tgt', val=4)
+
+        exec_comp = ExecComp('y=x**2', x={'value': 1}, y={'value': 1})
+
+        prob.model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
+
+        prob.model.add_subsystem(name='exec', subsys=exec_comp)
+
+        prob.model.add_subsystem(name='balance', subsys=bal)
+
+        prob.model.connect('y_tgt', 'balance.rhs:x')
+        prob.model.connect('balance.x', 'exec.x')
+        prob.model.connect('exec.y', 'balance.lhs:x')
+
+        prob.model.linear_solver = DirectSolver()
+
+        prob.model.nonlinear_solver = NewtonSolver()
+        prob.model.nonlinear_solver.options['maxiter'] = 100
+        prob.model.nonlinear_solver.options['iprint'] = 0
+
+        prob.model.jacobian = DenseJacobian()
+
+        prob.setup()
+
+        prob['balance.x'] = np.random.rand(n)
+
+        prob.run_model()
+
+        assert_almost_equal(prob['balance.x'], 2.0, decimal=7)
+
+        np.set_printoptions(linewidth=1024)
+
+        cpd = prob.check_partials()
+
+        for (of, wrt) in cpd['balance']:
+            assert_almost_equal(cpd['balance'][of, wrt]['abs error'], 0.0, decimal=5)
+
+    def test_scalar_with_mult(self):
+
+        n = 1
+
+        prob = Problem(model=Group())
+
+        bal = BalanceComp()
+
+        bal.add_balance('x')
+
+        tgt = IndepVarComp(name='y_tgt', val=4)
+
+        mult_ivc = IndepVarComp(name='mult', val=2.0)
+
+        exec_comp = ExecComp('y=x**2', x={'value': 1}, y={'value': 1})
+
+        prob.model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
+        prob.model.add_subsystem(name='mult_comp', subsys=mult_ivc, promotes_outputs=['mult'])
+
+        prob.model.add_subsystem(name='exec', subsys=exec_comp)
+
+        prob.model.add_subsystem(name='balance', subsys=bal)
+
+        prob.model.connect('y_tgt', 'balance.rhs:x')
+        prob.model.connect('mult', 'balance.mult:x')
+        prob.model.connect('balance.x', 'exec.x')
+        prob.model.connect('exec.y', 'balance.lhs:x')
+
+        prob.model.linear_solver = DirectSolver()
+
+        prob.model.nonlinear_solver = NewtonSolver()
+        prob.model.nonlinear_solver.options['maxiter'] = 100
+        prob.model.nonlinear_solver.options['iprint'] = 0
+
+        prob.model.jacobian = DenseJacobian()
+
+        prob.setup()
+
+        prob['balance.x'] = np.random.rand(n)
+
+        prob.run_model()
+
+        assert_almost_equal(prob['balance.x'], np.sqrt(2), decimal=7)
+
+        np.set_printoptions(linewidth=1024)
+
+        cpd = prob.check_partials()
+
+        for (of, wrt) in cpd['balance']:
+            assert_almost_equal(cpd['balance'][of, wrt]['abs error'], 0.0, decimal=5)
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
BalanceComp makes it easier for novice users to define simple implicit equations by giving them an ImplicitComponent to which they connect the LHS and RHS of a residual equation:

resid = mult * LHS - RHS

When abs(RHS) >= 2, the residual equation is automatically scaled by (1/RHS).  When abs(RHS) < 2, the residual equation is scaled by a paraboloid that avoids the singularity at RHS=0 yet still provides smoothness at the interface of RHS=2.

New implicit relationships are added with `add_balance(name, eq_units=None, mult_val=1.0, **kwargs)`, where name is the name of the new implicit state variable.  For instance, adding `name=x` automatically creates a new output named `x`, as well as inputs named `mult:x`, `lhs:x`, and `rhs:x`.  `mult:x` is assumed to have no units, while units for `lhs:x` and `rhs:x` are optionally provided with the `eq_units` argument.

All other options in `**kwargs` are forwarded to the `add_output` call at setup.  The implicit state may be declared a vector by providing an initial value `val=np.ones(N)` where N is some positive integer.

If left unconnected, the multiplier will have a default value of `mult_val`.  It must be compatible with the shape of the implicit state.  