### PR TITLE
Doc cleanup

### DIFF
--- a/openmdao/api.py
+++ b/openmdao/api.py
@@ -10,6 +10,7 @@ from openmdao.core.indepvarcomp import IndepVarComp
 from openmdao.core.analysis_error import AnalysisError
 
 # Components
+from openmdao.components.balance_comp import BalanceComp
 from openmdao.components.deprecated_component import Component
 from openmdao.components.exec_comp import ExecComp
 from openmdao.components.linear_system_comp import LinearSystemComp

--- a/openmdao/components/tests/test_balance_comp.py
+++ b/openmdao/components/tests/test_balance_comp.py
@@ -7,7 +7,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal
 from openmdao.api import Problem, Group, IndepVarComp, ExecComp, \
     NewtonSolver, DirectSolver, DenseJacobian
-from openmdao.components.balance_comp import BalanceComp
+from openmdao.api import BalanceComp
 
 
 class TestBalanceComp(unittest.TestCase):

--- a/openmdao/core/tests/test_impl_comp.py
+++ b/openmdao/core/tests/test_impl_comp.py
@@ -284,8 +284,8 @@ class ImplicitCompTestCase(unittest.TestCase):
                 pass
 
             def guess_nonlinear(self, inputs, outputs, resids):
-                # Solution at 1 and 3. Default value takes us to -1 solution. Here
-                # we set it to a value that will tke us to the 3 solution.
+                # Solution at x=1 and x=3. Default value takes us to the x=1 solution. Here
+                # we set it to a value that will take us to the x=3 solution.
                 outputs['x'] = 5.0
 
 

--- a/openmdao/docs/tutorials/first_analysis.rst
+++ b/openmdao/docs/tutorials/first_analysis.rst
@@ -32,7 +32,7 @@ Preamble
 ::
 
     from __future__ import division, print_function
-    from openmdao.core.explicitcomponent import ExplicitComponent
+    from openmdao.api import ExplicitComponent
 
 At the top of any script you'll see these lines (or lines very similar to these) which import needed classes and functions. On the first import line the `print_function` is used so the code in the script will work in python 2.0 or 3.0. If you want to know whats going on with the division operator, check out this `detailed explanation <https://www.python.org/dev/peps/pep-0238/>`_. The second import line brings in OpenMDAO classes that are needed to build and run a model.
 As you progress to more complex models you can expect to import more classes from `openmdao.api`, but for now we only need these 4.
@@ -87,9 +87,9 @@ You can read more about how OpenMDAO handles units and scaling here[LINK TO FEAT
 .. code::
 
     if __name__ == "__main__":
-        from openmdao.core.problem import Problem
-        from openmdao.core.group import Group
-        from openmdao.core.indepvarcomp import IndepVarComp
+        from openmdao.api import Problem
+        from openmdao.api import Group
+        from openmdao.api import IndepVarComp
 
         model = Group()
         ivc = IndepVarComp()

--- a/openmdao/docs/tutorials/first_analysis.rst
+++ b/openmdao/docs/tutorials/first_analysis.rst
@@ -34,7 +34,7 @@ Preamble
     from __future__ import division, print_function
     from openmdao.api import ExplicitComponent
 
-At the top of any script you'll see these lines (or lines very similar to these) which import needed classes and functions. On the first import line the `print_function` is used so the code in the script will work in python 2 or 3. If you want to know whats going on with the division operator, check out this `detailed explanation <https://www.python.org/dev/peps/pep-0238/>`_. The second import line brings in OpenMDAO classes that are needed to build and run a model.
+At the top of any script you'll see these lines (or lines very similar to these) which import needed classes and functions. On the first import line the `print_function` is used so the code in the script will work in Python 2 or 3. If you want to know whats going on with the division operator, check out this `detailed explanation <https://www.python.org/dev/peps/pep-0238/>`_. The second import line brings in OpenMDAO classes that are needed to build and run a model.
 As you progress to more complex models you can expect to import more classes from `openmdao.api`, but for now we only need these 4.
 
 Defining a component

--- a/openmdao/docs/tutorials/first_analysis.rst
+++ b/openmdao/docs/tutorials/first_analysis.rst
@@ -34,7 +34,7 @@ Preamble
     from __future__ import division, print_function
     from openmdao.api import ExplicitComponent
 
-At the top of any script you'll see these lines (or lines very similar to these) which import needed classes and functions. On the first import line the `print_function` is used so the code in the script will work in python 2.0 or 3.0. If you want to know whats going on with the division operator, check out this `detailed explanation <https://www.python.org/dev/peps/pep-0238/>`_. The second import line brings in OpenMDAO classes that are needed to build and run a model.
+At the top of any script you'll see these lines (or lines very similar to these) which import needed classes and functions. On the first import line the `print_function` is used so the code in the script will work in python 2 or 3. If you want to know whats going on with the division operator, check out this `detailed explanation <https://www.python.org/dev/peps/pep-0238/>`_. The second import line brings in OpenMDAO classes that are needed to build and run a model.
 As you progress to more complex models you can expect to import more classes from `openmdao.api`, but for now we only need these 4.
 
 Defining a component


### PR DESCRIPTION
Removed reference to `from openmdao.core.blah import Blah` in the tutorials.  Fixed a typo in the implicit component test documentation.