### PR TITLE
Balance update: rename lhs, rhs, and mult

### DIFF
--- a/openmdao/components/balance_comp.py
+++ b/openmdao/components/balance_comp.py
@@ -132,19 +132,7 @@ class BalanceComp(ImplicitComponent):
 
             for s in ('lhs', 'rhs', 'mult'):
                 if options['{0}_name'.format(s)] is None:
-                    options['{0}_name'.format(s)] = '{0}:{1}'.format(s,name)
-
-            # if options['lhs_name'] is None:
-            #     lhs_name = 'lhs:{0}'.format(name)
-            #     self._state_vars[name]['lhs_name'] = lhs_name
-            #
-            # if options['rhs_name'] is None:
-            #     rhs_name = 'rhs:{0}'.format(name)
-            #     self._state_vars[name]['rhs_name'] = rhs_name
-            #
-            # if options['mult_name'] is None:
-            #     mult_name = 'mult:{0}'.format(name)
-            #     self._state_vars[name]['mult_name'] = mult_name
+                    options['{0}_name'.format(s)] = '{0}:{1}'.format(s, name)
 
             val = options['kwargs'].get('val', np.ones(1))
             if isinstance(val, Number):

--- a/openmdao/components/tests/test_balance_comp.py
+++ b/openmdao/components/tests/test_balance_comp.py
@@ -86,7 +86,6 @@ class TestBalanceComp(unittest.TestCase):
         for (of, wrt) in cpd['balance']:
             assert_almost_equal(cpd['balance'][of, wrt]['abs error'], 0.0, decimal=5)
 
-
     def test_vectorized(self):
 
         n = 100

--- a/openmdao/components/tests/test_balance_comp.py
+++ b/openmdao/components/tests/test_balance_comp.py
@@ -340,7 +340,7 @@ class TestBalanceComp(unittest.TestCase):
 
         bal = BalanceComp()
 
-        bal.add_balance('x', mult_name='MULX', lhs_name='XSQ', rhs_name='TARGETXSQ')
+        bal.add_balance('x', mult_name='MUL', lhs_name='XSQ', rhs_name='TARGETXSQ')
 
         tgt = IndepVarComp(name='y_tgt', val=4)
 
@@ -356,7 +356,7 @@ class TestBalanceComp(unittest.TestCase):
         prob.model.add_subsystem(name='balance', subsys=bal)
 
         prob.model.connect('y_tgt', 'balance.TARGETXSQ')
-        prob.model.connect('mult', 'balance.MULX')
+        prob.model.connect('mult', 'balance.MUL')
         prob.model.connect('balance.x', 'exec.x')
         prob.model.connect('exec.y', 'balance.XSQ')
 


### PR DESCRIPTION
Adds the ability to rename the lhs, rhs, and mult inputs associated with a given implicit state in BalanceComp. 