### PR TITLE
Small comment and printing update now that registration on /visualization is up

### DIFF
--- a/openmdao/recorders/web_recorder.py
+++ b/openmdao/recorders/web_recorder.py
@@ -38,7 +38,8 @@ class WebRecorder(BaseRecorder):
         Parameters
         ----------
         token: <string>
-            The token to be passed as a passphrase for authentication of each server request
+            The token to be passed as a user's unique identifier. Register to get a token
+            at the given endpoint
         case_name: <string>
             The name this case should be stored under. Default: 'Case Recording'
         endpoint: <string>
@@ -46,8 +47,7 @@ class WebRecorder(BaseRecorder):
         port: <string>
             The port which the server is listening on. Default to empty string (port 80)
         suppress_output: <bool>
-            Indicates if any printing should occur (including printing indicating the
-            visualization URL)
+            Indicates if all printing should be suppressed in this recorder
         """
         super(WebRecorder, self).__init__()
 
@@ -70,8 +70,6 @@ class WebRecorder(BaseRecorder):
         response = case_request.json()
         if response['status'] != 'Failed':
             self._case_id = str(response['case_id'])
-            if not suppress_output:
-                print("Visualization at: http://openmdao.org/visualization/case/" + self._case_id)
         else:
             self._case_id = '-1'
             if not suppress_output:

--- a/openmdao/recorders/web_recorder.py
+++ b/openmdao/recorders/web_recorder.py
@@ -73,8 +73,9 @@ class WebRecorder(BaseRecorder):
         else:
             self._case_id = '-1'
             if not suppress_output:
-                print("Failed to initialize case on server. No messages will be accepted\
-                 from server for this case.")
+                print("Failed to initialize case on server. No messages will be accepted \
+                from server for this case. Make sure you registered for a token at the \
+                given endpoint.")
 
             if 'reasoning' in response:
                 if not suppress_output:


### PR DESCRIPTION
Updated comments and printing to indicate that you register for a token at the endpoint that you use. Removed logging the endpoint of the visualization, as it is now unnecessary; users can view all of their recordings by logging in at the endpoint used for registration.