### PR TITLE
Connection rules

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -586,7 +586,8 @@ class Group(System):
                         msg = ("The source and target shapes do not match or are ambiguous"
                                " for the connection '%s' to '%s'. Expected %s but got %s.")
                         raise ValueError(msg % (abs_out, abs_in,
-                                                in_shape, out_shape))
+                                                tuple([int(s) for s in in_shape]),
+                                                tuple([int(s) for s in out_shape])))
 
                 if src_indices is not None:
                     src_indices = np.atleast_1d(src_indices)

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -579,10 +579,14 @@ class Group(System):
                 flat = abs2meta_in[abs_in]['flat_src_indices']
 
                 if src_indices is None and out_shape != in_shape:
-                    msg = ("The source and target shapes do not match"
-                           " for the connection '%s' to '%s'. Expected %s but got %s.")
-                    raise ValueError(msg % (abs_out, abs_in,
-                                            in_shape, out_shape))
+                    # out_shape != in_shape is allowed if
+                    # there's no ambiguity in storage order
+                    if not (np.prod(out_shape) == np.prod(in_shape)
+                            == np.max(out_shape) == np.max(in_shape)):
+                        msg = ("The source and target shapes do not match or are ambiguous"
+                               " for the connection '%s' to '%s'. Expected %s but got %s.")
+                        raise ValueError(msg % (abs_out, abs_in,
+                                                in_shape, out_shape))
 
                 if src_indices is not None:
                     src_indices = np.atleast_1d(src_indices)

--- a/openmdao/core/tests/test_connections.py
+++ b/openmdao/core/tests/test_connections.py
@@ -7,6 +7,7 @@ from six.moves import cStringIO, range
 from six import assertRaisesRegex
 
 from openmdao.api import Problem, Group, IndepVarComp, ExecComp, ExplicitComponent
+from openmdao.devtools.testutil import assert_rel_error
 
 
 class TestConnections(unittest.TestCase):
@@ -422,7 +423,7 @@ class TestConnectionsIndices(unittest.TestCase):
         # Should not be allowed because the source and target shapes do not match
         self.prob.model.connect('idvp.blammo', 'arraycomp.inp')
 
-        expected = ("The source and target shapes do not match for the "
+        expected = ("The source and target shapes do not match or are ambiguous for the "
                     "connection 'idvp.blammo' to 'arraycomp.inp'."
                     " Expected \(2.*,\) but got \(1.*,\).")
 
@@ -458,8 +459,96 @@ class TestConnectionsIndices(unittest.TestCase):
         else:
             self.fail('Exception expected.')
 
+        def test_connect_flat_array_to_row_vector(self):
+            p = Problem()
+            p.model.add_subsystem('indep', IndepVarComp('x', val=np.arange(10)))
+            p.model.add_subsystem('C1',
+                                  ExecComp('y=numpy.dot(x, A)',
+                                           x={'value': np.zeros((1, 10))},
+                                           A={'value': np.eye(10)},
+                                           y={'value': np.zeros((1, 10))}))
+            p.model.connect('indep.x', 'C1.x')
+            p.setup()
+            p.run_model()
+            assert_rel_error(self, p['C1.y'], np.arange(10)[np.newaxis, :])
 
-#class TestUBCS(unittest.TestCase):
+        def test_connect_flat_array_to_col_vector(self):
+            p = Problem()
+            p.model.add_subsystem('indep', IndepVarComp('x', val=np.arange(10)))
+            p.model.add_subsystem('C1',
+                                  ExecComp('y=numpy.dot(A, x)',
+                                           x={'value': np.zeros((10, 1))},
+                                           A={'value': np.eye(10)},
+                                           y={'value': np.zeros((10, 1))}))
+            p.model.connect('indep.x', 'C1.x')
+            p.setup()
+            p.run_model()
+            assert_rel_error(self, p['C1.y'], np.arange(10)[:, np.newaxis])
+
+        def test_connect_row_vector_to_flat_array(self):
+            p = Problem()
+            p.model.add_subsystem('indep', IndepVarComp('x', val=np.arange(10)[np.newaxis, :]))
+            p.model.add_subsystem('C1', ExecComp('y=5*x',
+                                                 x={'value': np.zeros(10)},
+                                                 y={'value': np.zeros(10)}))
+            p.model.connect('indep.x', 'C1.x')
+            p.setup()
+            p.run_model()
+            assert_rel_error(self, p['C1.y'], 5 * np.arange(10))
+
+        def test_connect_col_vector_to_flat_array(self):
+            p = Problem()
+            p.model.add_subsystem('indep', IndepVarComp('x', val=np.arange(10)[:, np.newaxis]))
+            p.model.add_subsystem('C1', ExecComp('y=5*x',
+                                                 x={'value': np.zeros(10)},
+                                                 y={'value': np.zeros(10)}))
+            p.model.connect('indep.x', 'C1.x')
+            p.setup()
+            p.run_model()
+            assert_rel_error(self, p['C1.y'], 5 * np.arange(10))
+
+        def test_connect_flat_to_3d_array(self):
+            p = Problem()
+            p.model.add_subsystem('indep', IndepVarComp('x', val=np.arange(10)))
+            p.model.add_subsystem('C1', ExecComp('y=5*x',
+                                                 x={'value': np.zeros((1, 10, 1))},
+                                                 y={'value': np.zeros((1, 10, 1))}))
+            p.model.connect('indep.x', 'C1.x')
+            p.setup()
+            p.run_model()
+            assert_rel_error(self, p['C1.y'], 5 * np.arange(10)[np.newaxis, :, np.newaxis])
+
+        def test_connect_flat_nd_to_flat_nd(self):
+            p = Problem()
+            p.model.add_subsystem('indep', IndepVarComp('x',
+                                                        val=np.arange(10)[np.newaxis, :, np.newaxis,
+                                                            np.newaxis]))
+            p.model.add_subsystem('C1', ExecComp('y=5*x',
+                                                 x={'value': np.zeros((1, 1, 1, 10))},
+                                                 y={'value': np.zeros((1, 1, 1, 10))}))
+            p.model.connect('indep.x', 'C1.x')
+            p.setup()
+            p.run_model()
+            assert_rel_error(self, p['C1.y'],
+                             5 * np.arange(10)[np.newaxis, np.newaxis, np.newaxis, :])
+
+        def test_connect_incompatible_shapes(self):
+            p = Problem()
+            p.model.add_subsystem('indep', IndepVarComp('x', val=np.arange(10)[np.newaxis, :,
+                                                                 np.newaxis, np.newaxis]))
+            p.model.add_subsystem('C1', ExecComp('y=5*x',
+                                                 x={'value': np.zeros((5, 2))},
+                                                 y={'value': np.zeros((5, 2))}))
+            p.model.connect('indep.x', 'C1.x')
+
+            with self.assertRaises(Exception) as context:
+                p.setup()
+            self.assertEqual(str(context.exception),
+                             "The source and target shapes do not match or are ambiguous "
+                             "for the connection 'indep.x' to 'C1.x'. Expected (5, 2) but "
+                             "got (1, 10, 1, 1).")
+
+        #class TestUBCS(unittest.TestCase):
 
     #def test_ubcs(self):
         #p = Problem(model=Group())

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -1081,7 +1081,7 @@ class TestConnect(unittest.TestCase):
     def test_bad_shapes(self):
         self.sub.connect('src.s', 'arr.x')
 
-        msg = ("The source and target shapes do not match for the connection "
+        msg = ("The source and target shapes do not match or are ambiguous for the connection "
                "'sub.src.s' to 'sub.arr.x'.")
 
         with assertRaisesRegex(self, ValueError, msg):


### PR DESCRIPTION
Loosens the rules on connections such that two variables of different shapes can be connected if the storage order is unambiguous.  If the source or target is multidimensional, then all dimensions except for one must have length 1, and the size of the source and target must be compatible.  Flat arrays can be connected to row or column vectors of the same length, and vice-versa.
