### PR TITLE
A little refactoring in solver, particularly Newton

### DIFF
--- a/openmdao/recorders/recording_iteration_stack.py
+++ b/openmdao/recorders/recording_iteration_stack.py
@@ -95,7 +95,7 @@ class Recording(object):
         # Determine if recording is justified.
         do_recording = True
         for stack_item in recording_iteration_stack:
-            if stack_item[0] in ('_iter_get_norm', '_compute_total_derivs'):
+            if stack_item[0] in ('_run_apply', '_compute_total_derivs'):
                 do_recording = False
                 break
 

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -822,7 +822,7 @@ class TestSqliteRecorder(unittest.TestCase):
         self.prob.cleanup()
 
         coordinate = [0, 'Driver', (0,), 'root._solve_nonlinear', (0,), 'NewtonSolver', (3,), 'ArmijoGoldsteinLS', (4,)]
-        expected_abs_error = model._residuals.get_norm()
+        expected_abs_error = 3.49773898733e-9
         expected_rel_error = expected_abs_error / 2.9086436370499857e-08
         expected_solver_output = None
         expected_solver_residuals = None

--- a/openmdao/recorders/tests/test_web_recorder.py
+++ b/openmdao/recorders/tests/test_web_recorder.py
@@ -549,7 +549,7 @@ class TestServerRecorder(unittest.TestCase):
 
         self.prob.cleanup()
 
-        expected_abs_error = model._residuals.get_norm()
+        expected_abs_error = 3.49773898733e-9
         expected_rel_error = expected_abs_error / 2.9086436370499857e-08
 
         solver_iteration = json.loads(self.solver_iterations)

--- a/openmdao/solvers/linesearch/backtracking.py
+++ b/openmdao/solvers/linesearch/backtracking.py
@@ -108,6 +108,8 @@ class BoundsEnforceLS(NonlinearSolver):
         u = system._outputs
         du = system._vectors['output']['linear']
 
+        self._run_apply()
+
         norm0 = self._iter_get_norm()
         if norm0 == 0.0:
             norm0 = 1.0
@@ -125,6 +127,7 @@ class BoundsEnforceLS(NonlinearSolver):
             elif self.options['bound_enforcement'] == 'wall':
                 u._enforce_bounds_wall(du, 1.0, system._lower_bounds, system._upper_bounds)
 
+            self._run_apply()
             norm = self._iter_get_norm()
             # With solvers, we want to record the norm AFTER
             # the call, but the call needs to
@@ -189,6 +192,7 @@ class ArmijoGoldsteinLS(NonlinearSolver):
         u = system._outputs
         du = system._vectors['output']['linear']
 
+        self._run_apply()
         norm0 = self._iter_get_norm()
         if norm0 == 0.0:
             norm0 = 1.0
@@ -206,6 +210,7 @@ class ArmijoGoldsteinLS(NonlinearSolver):
             u._enforce_bounds_wall(du, self.alpha, system._lower_bounds, system._upper_bounds)
 
         try:
+            self._run_apply()
             norm = self._iter_get_norm()
 
         except AnalysisError as err:
@@ -315,6 +320,7 @@ class ArmijoGoldsteinLS(NonlinearSolver):
                 self._iter_execute()
                 self._iter_count += 1
                 try:
+                    self._run_apply()
                     norm = self._iter_get_norm()
 
                     # With solvers, we want to report the norm AFTER

--- a/openmdao/solvers/nonlinear/newton.py
+++ b/openmdao/solvers/nonlinear/newton.py
@@ -134,7 +134,7 @@ class NewtonSolver(NonlinearSolver):
         """
         Run the the apply_nonlinear method on the system.
         """
-        recording_iteration_stack.append(('_iter_get_norm', 0))
+        recording_iteration_stack.append(('_run_apply', 0))
 
         system = self._system
 

--- a/openmdao/solvers/nonlinear/newton.py
+++ b/openmdao/solvers/nonlinear/newton.py
@@ -215,7 +215,7 @@ class NewtonSolver(NonlinearSolver):
         system = self._system
         self._solver_info.prefix += '|  '
         do_subsolve = self.options['solve_subsystems'] and \
-            (self._iter_count <= self.options['max_sub_solves'])
+            (self._iter_count < self.options['max_sub_solves'])
 
         # Disable local fd
         approx_status = system._owns_approx_jac

--- a/openmdao/solvers/nonlinear/tests/test_newton.py
+++ b/openmdao/solvers/nonlinear/tests/test_newton.py
@@ -664,9 +664,9 @@ class TestNewton(unittest.TestCase):
         prob.run_model()
 
         # Verifying subsolvers ran
-        self.assertEqual(g1.nonlinear_solver.total_count, 4)
-        self.assertEqual(g2.nonlinear_solver.total_count, 4)
-        self.assertEqual(g1.linear_solver.lin_count, 4)
+        self.assertEqual(g1.nonlinear_solver.total_count, 2)
+        self.assertEqual(g2.nonlinear_solver.total_count, 2)
+        self.assertEqual(g1.linear_solver.lin_count, 2)
 
         prob = Problem()
         model = prob.model = DoubleSellar()
@@ -730,9 +730,9 @@ class TestNewton(unittest.TestCase):
         prob.run_model()
 
         # Verifying subsolvers ran
-        self.assertEqual(g1.nonlinear_solver.total_count, 5)
-        self.assertEqual(g2.nonlinear_solver.total_count, 5)
-        self.assertEqual(g1.linear_solver.lin_count, 5)
+        self.assertEqual(g1.nonlinear_solver.total_count, 4)
+        self.assertEqual(g2.nonlinear_solver.total_count, 4)
+        self.assertEqual(g1.linear_solver.lin_count, 4)
 
     def test_maxiter_one(self):
         # Fix bug when maxiter was set to 1.

--- a/openmdao/solvers/nonlinear/tests/test_newton.py
+++ b/openmdao/solvers/nonlinear/tests/test_newton.py
@@ -664,9 +664,9 @@ class TestNewton(unittest.TestCase):
         prob.run_model()
 
         # Verifying subsolvers ran
-        self.assertEqual(g1.nonlinear_solver.total_count, 2)
-        self.assertEqual(g2.nonlinear_solver.total_count, 2)
-        self.assertEqual(g1.linear_solver.lin_count, 2)
+        self.assertEqual(g1.nonlinear_solver.total_count, 4)
+        self.assertEqual(g2.nonlinear_solver.total_count, 4)
+        self.assertEqual(g1.linear_solver.lin_count, 4)
 
         prob = Problem()
         model = prob.model = DoubleSellar()
@@ -730,9 +730,9 @@ class TestNewton(unittest.TestCase):
         prob.run_model()
 
         # Verifying subsolvers ran
-        self.assertEqual(g1.nonlinear_solver.total_count, 4)
-        self.assertEqual(g2.nonlinear_solver.total_count, 4)
-        self.assertEqual(g1.linear_solver.lin_count, 4)
+        self.assertEqual(g1.nonlinear_solver.total_count, 5)
+        self.assertEqual(g2.nonlinear_solver.total_count, 5)
+        self.assertEqual(g1.linear_solver.lin_count, 5)
 
     def test_maxiter_one(self):
         # Fix bug when maxiter was set to 1.

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -214,6 +214,7 @@ class Solver(object):
             with Recording(type(self).__name__, self._iter_count, self) as rec:
                 self._iter_execute()
                 self._iter_count += 1
+                self._run_apply()
                 norm = self._iter_get_norm()
                 # With solvers, we want to record the norm AFTER the call, but the call needs to
                 # be wrapped in the with for stack purposes, so we locally assign  norm & norm0
@@ -263,6 +264,12 @@ class Solver(object):
     def _iter_execute(self):
         """
         Perform the operations in the iteration loop.
+        """
+        pass
+
+    def _run_apply(self):
+        """
+        Run the appropriate apply method on the system.
         """
         pass
 
@@ -365,11 +372,20 @@ class NonlinearSolver(Solver):
             error at the first iteration.
         """
         if self.options['maxiter'] > 0:
+            self._run_apply()
             norm = self._iter_get_norm()
         else:
             norm = 1.0
         norm0 = norm if norm != 0.0 else 1.0
         return norm0, norm
+
+    def _run_apply(self):
+        """
+        Run the the apply_nonlinear method on the system.
+        """
+        recording_iteration_stack.append(('_run_apply', 0))
+        self._system._apply_nonlinear()
+        recording_iteration_stack.pop()
 
     def _iter_get_norm(self):
         """
@@ -380,12 +396,6 @@ class NonlinearSolver(Solver):
         float
             norm.
         """
-        recording_iteration_stack.append(('_iter_get_norm', 0))
-
-        self._system._apply_nonlinear()
-
-        recording_iteration_stack.pop()
-
         return self._system._residuals.get_norm()
 
 
@@ -441,11 +451,24 @@ class LinearSolver(Solver):
             self._rhs_vecs[vec_name] = b_vecs[vec_name]._clone()
 
         if self.options['maxiter'] > 1:
+            self._run_apply()
             norm = self._iter_get_norm()
         else:
             norm = 1.0
         norm0 = norm if norm != 0.0 else 1.0
         return norm0, norm
+
+    def _run_apply(self):
+        """
+        Run the the apply_linear method on the system.
+        """
+        recording_iteration_stack.append(('_run_apply', 0))
+
+        system = self._system
+        scope_out, scope_in = system._get_scope()
+        system._apply_linear(self._vec_names, self._mode, scope_out, scope_in)
+
+        recording_iteration_stack.pop()
 
     def _iter_get_norm(self):
         """
@@ -456,13 +479,7 @@ class LinearSolver(Solver):
         float
             norm.
         """
-        recording_iteration_stack.append(('_iter_get_norm', 0))
-
         system = self._system
-        scope_out, scope_in = system._get_scope()
-        system._apply_linear(self._vec_names, self._mode, scope_out, scope_in)
-
-        recording_iteration_stack.pop()
 
         if self._mode == 'fwd':
             b_vecs = system._vectors['residual']


### PR DESCRIPTION
1. Removed the "apply" calls from `_get_iter_norm` and put them in their own method.
2. Rearranged order of events in Newton so that the initial subsolve is done in `_iter_initialize`, and any subsequent subsolves are after the linear solve in the main loop. This way, initial norms are always on the solved state.