### PR TITLE
Web Recorder serialization fix

### DIFF
--- a/openmdao/recorders/tests/test_web_recorder.py
+++ b/openmdao/recorders/tests/test_web_recorder.py
@@ -359,13 +359,7 @@ class TestServerRecorder(unittest.TestCase):
 
         self.prob.cleanup()
 
-        system_metadata = json.loads(self.system_metadata)
         system_iterations = json.loads(self.system_iterations)
-        scaling_facts_raw = system_metadata['scaling_factors']
-        scaling_facts_ascii = scaling_facts_raw.encode('ascii')
-        scaling_facts_base64 = base64.b64decode(scaling_facts_ascii)
-        scaling_facts = pickle.loads(scaling_facts_base64)
-        system_metadata['scaling_factors'] = scaling_facts
 
         inputs = [
             {'name': 'd1.z', 'values': [5.0, 2.0]},

--- a/openmdao/recorders/web_recorder.py
+++ b/openmdao/recorders/web_recorder.py
@@ -168,10 +168,10 @@ class WebRecorder(BaseRecorder):
             "iteration_coordinate": iteration_coordinate,
             "success": metadata['success'],
             "msg": metadata['msg'],
-            "desvars": self.convert_to_list(desvars_array),
-            "responses": self.convert_to_list(responses_array),
-            "objectives": self.convert_to_list(objectives_array),
-            "constraints": self.convert_to_list(constraints_array)
+            "desvars": [] if desvars_array is None else list(desvars_array),
+            "responses": [] if responses_array is None else list(responses_array),
+            "objectives": [] if objectives_array is None else list(objectives_array),
+            "constraints": [] if constraints_array is None else list(constraints_array)
         }
 
         global_iteration_dict = {
@@ -238,9 +238,9 @@ class WebRecorder(BaseRecorder):
             'iteration_coordinate': iteration_coordinate,
             'success': metadata['success'],
             'msg': metadata['msg'],
-            'inputs': self.convert_to_list(inputs_array),
-            'outputs': self.convert_to_list(outputs_array),
-            'residuals': self.convert_to_list(residuals_array)
+            'inputs': [] if inputs_array is None else list(inputs_array),
+            'outputs': [] if outputs_array is None else list(outputs_array),
+            'residuals': [] if residuals_array is None else list(residuals_array)
         }
 
         global_iteration_dict = {
@@ -301,8 +301,8 @@ class WebRecorder(BaseRecorder):
             'msg': metadata['msg'],
             'abs_err': self._abs_error,
             'rel_err': self._rel_error,
-            'solver_output': self.convert_to_list(outputs_array),
-            'solver_residuals': self.convert_to_list(residuals_array)
+            'solver_output': [] if outputs_array is None else list(outputs_array),
+            'solver_residuals': [] if residuals_array is None else list(residuals_array)
         }
 
         global_iteration_dict = {

--- a/openmdao/recorders/web_recorder.py
+++ b/openmdao/recorders/web_recorder.py
@@ -347,16 +347,7 @@ class WebRecorder(BaseRecorder):
         object_requesting_recording: <System>
             The System that would like to record its metadata.
         """
-        scaling_vecs = pickle.dumps(object_requesting_recording._scaling_vecs,
-                                    pickle.HIGHEST_PROTOCOL)
-        encoded_scaling_vecs = base64.b64encode(scaling_vecs)
-        system_metadata_dict = {
-            'id': object_requesting_recording.pathname,
-            'scaling_factors': encoded_scaling_vecs.decode('ascii')
-        }
-        system_metadata = json.dumps(system_metadata_dict)
-        requests.post(self._endpoint + '/' + self._case_id + '/system_metadata',
-                      data=system_metadata, headers=self._headers)
+        pass
 
     def record_metadata_solver(self, object_requesting_recording):
         """

--- a/openmdao/recorders/web_recorder.py
+++ b/openmdao/recorders/web_recorder.py
@@ -168,10 +168,10 @@ class WebRecorder(BaseRecorder):
             "iteration_coordinate": iteration_coordinate,
             "success": metadata['success'],
             "msg": metadata['msg'],
-            "desvars": [] if desvars_array is None else list(desvars_array),
-            "responses": [] if responses_array is None else list(responses_array),
-            "objectives": [] if objectives_array is None else list(objectives_array),
-            "constraints": [] if constraints_array is None else list(constraints_array)
+            "desvars": [] if desvars_array is None else desvars_array,
+            "responses": [] if responses_array is None else responses_array,
+            "objectives": [] if objectives_array is None else objectives_array,
+            "constraints": [] if constraints_array is None else constraints_array
         }
 
         global_iteration_dict = {
@@ -238,9 +238,9 @@ class WebRecorder(BaseRecorder):
             'iteration_coordinate': iteration_coordinate,
             'success': metadata['success'],
             'msg': metadata['msg'],
-            'inputs': [] if inputs_array is None else list(inputs_array),
-            'outputs': [] if outputs_array is None else list(outputs_array),
-            'residuals': [] if residuals_array is None else list(residuals_array)
+            'inputs': [] if inputs_array is None else inputs_array,
+            'outputs': [] if outputs_array is None else outputs_array,
+            'residuals': [] if residuals_array is None else residuals_array
         }
 
         global_iteration_dict = {
@@ -301,8 +301,8 @@ class WebRecorder(BaseRecorder):
             'msg': metadata['msg'],
             'abs_err': self._abs_error,
             'rel_err': self._rel_error,
-            'solver_output': [] if outputs_array is None else list(outputs_array),
-            'solver_residuals': [] if residuals_array is None else list(residuals_array)
+            'solver_output': [] if outputs_array is None else outputs_array,
+            'solver_residuals': [] if residuals_array is None else residuals_array
         }
 
         global_iteration_dict = {

--- a/openmdao/recorders/web_recorder.py
+++ b/openmdao/recorders/web_recorder.py
@@ -168,10 +168,10 @@ class WebRecorder(BaseRecorder):
             "iteration_coordinate": iteration_coordinate,
             "success": metadata['success'],
             "msg": metadata['msg'],
-            "desvars": list(desvars_array),
-            "responses": list(responses_array),
-            "objectives": list(objectives_array),
-            "constraints": list(constraints_array)
+            "desvars": self.convert_to_list(desvars_array),
+            "responses": self.convert_to_list(responses_array),
+            "objectives": self.convert_to_list(objectives_array),
+            "constraints": self.convert_to_list(constraints_array)
         }
 
         global_iteration_dict = {
@@ -238,9 +238,9 @@ class WebRecorder(BaseRecorder):
             'iteration_coordinate': iteration_coordinate,
             'success': metadata['success'],
             'msg': metadata['msg'],
-            'inputs': list(inputs_array),
-            'outputs': list(outputs_array),
-            'residuals': list(residuals_array)
+            'inputs': self.convert_to_list(inputs_array),
+            'outputs': self.convert_to_list(outputs_array),
+            'residuals': self.convert_to_list(residuals_array)
         }
 
         global_iteration_dict = {
@@ -301,8 +301,8 @@ class WebRecorder(BaseRecorder):
             'msg': metadata['msg'],
             'abs_err': self._abs_error,
             'rel_err': self._rel_error,
-            'solver_output': list(outputs_array),
-            'solver_residuals': list(residuals_array)
+            'solver_output': self.convert_to_list(outputs_array),
+            'solver_residuals': self.convert_to_list(residuals_array)
         }
 
         global_iteration_dict = {

--- a/openmdao/recorders/web_recorder.py
+++ b/openmdao/recorders/web_recorder.py
@@ -113,7 +113,7 @@ class WebRecorder(BaseRecorder):
                 for name, value in iteritems(desvars_values):
                     desvars_array.append({
                         'name': name,
-                        'values': list(value)
+                        'values': self.convert_to_list(value)
                     })
 
         if self.options['record_responses']:
@@ -128,7 +128,7 @@ class WebRecorder(BaseRecorder):
                 for name, value in iteritems(responses_values):
                     responses_array.append({
                         'name': name,
-                        'values': list(value)
+                        'values': self.convert_to_list(value)
                     })
 
         if self.options['record_objectives']:
@@ -143,7 +143,7 @@ class WebRecorder(BaseRecorder):
                 for name, value in iteritems(objectives_values):
                     objectives_array.append({
                         'name': name,
-                        'values': list(value)
+                        'values': self.convert_to_list(value)
                     })
 
         if self.options['record_constraints']:
@@ -158,7 +158,7 @@ class WebRecorder(BaseRecorder):
                 for name, value in iteritems(constraints_values):
                     constraints_array.append({
                         'name': name,
-                        'values': list(value)
+                        'values': self.convert_to_list(value)
                     })
 
         iteration_coordinate = get_formatted_iteration_coordinate()
@@ -168,10 +168,10 @@ class WebRecorder(BaseRecorder):
             "iteration_coordinate": iteration_coordinate,
             "success": metadata['success'],
             "msg": metadata['msg'],
-            "desvars": self.convert_to_list(desvars_array),
-            "responses": self.convert_to_list(responses_array),
-            "objectives": self.convert_to_list(objectives_array),
-            "constraints": self.convert_to_list(constraints_array)
+            "desvars": list(desvars_array),
+            "responses": list(responses_array),
+            "objectives": list(objectives_array),
+            "constraints": list(constraints_array)
         }
 
         global_iteration_dict = {
@@ -210,7 +210,7 @@ class WebRecorder(BaseRecorder):
             for name, value in iteritems(self._inputs):
                 inputs_array.append({
                     'name': name,
-                    'values': list(value)
+                    'values': self.convert_to_list(value)
                 })
 
         # Outputs
@@ -219,7 +219,7 @@ class WebRecorder(BaseRecorder):
             for name, value in iteritems(self._outputs):
                 outputs_array.append({
                     'name': name,
-                    'values': list(value)
+                    'values': self.convert_to_list(value)
                 })
 
         # Residuals
@@ -228,18 +228,19 @@ class WebRecorder(BaseRecorder):
             for name, value in iteritems(self._resids):
                 residuals_array.append({
                     'name': name,
-                    'values': list(value)
+                    'values': self.convert_to_list(value)
                 })
 
         iteration_coordinate = get_formatted_iteration_coordinate()
+
         system_iteration_dict = {
             'counter': self._counter,
             'iteration_coordinate': iteration_coordinate,
             'success': metadata['success'],
             'msg': metadata['msg'],
-            'inputs': self.convert_to_list(inputs_array),
-            'outputs': self.convert_to_list(outputs_array),
-            'residuals': self.convert_to_list(residuals_array)
+            'inputs': list(inputs_array),
+            'outputs': list(outputs_array),
+            'residuals': list(residuals_array)
         }
 
         global_iteration_dict = {
@@ -280,7 +281,7 @@ class WebRecorder(BaseRecorder):
             for name, value in iteritems(self._outputs):
                 outputs_array.append({
                     'name': name,
-                    'values': list(value)
+                    'values': self.convert_to_list(value)
                 })
 
         residuals_array = []
@@ -288,7 +289,7 @@ class WebRecorder(BaseRecorder):
             for name, value in iteritems(self._resids):
                 residuals_array.append({
                     'name': name,
-                    'values': list(value)
+                    'values': self.convert_to_list(value)
                 })
 
         iteration_coordinate = get_formatted_iteration_coordinate()
@@ -300,8 +301,8 @@ class WebRecorder(BaseRecorder):
             'msg': metadata['msg'],
             'abs_err': self._abs_error,
             'rel_err': self._rel_error,
-            'solver_output': self.convert_to_list(outputs_array),
-            'solver_residuals': self.convert_to_list(residuals_array)
+            'solver_output': list(outputs_array),
+            'solver_residuals': list(residuals_array)
         }
 
         global_iteration_dict = {


### PR DESCRIPTION
Instead of casting to a list - which only ensures that the top level is JSON serializable - use convert_to_list which iterates over the entire structure and converts numpy arrays to lists to ensure that the entire structure is JSON serializable. Fix for PyCycle's CFM56 error when using the web recorder.

Additionally, removed recording scaling vectors as they ended up being very large and useless for visualization at this time.