### PR TITLE
fix for updating networkx to version 2

### DIFF
--- a/openmdao/devtools/problem_viewer/problem_viewer.py
+++ b/openmdao/devtools/problem_viewer/problem_viewer.py
@@ -135,8 +135,8 @@ def _get_viewer_data(problem_or_rootgroup_or_filename):
                 exe_src = component_execution_orders[src_subsystem]
                 exe_low = min(exe_tgt,exe_src)
                 exe_high = max(exe_tgt,exe_src)
-                subg = G.subgraph(li)
-                for n in subg.nodes():
+                subg = G.subgraph(li).copy()
+                for n in list(subg.nodes()):
                     exe_order = component_execution_orders[n]
                     if(exe_order < exe_low or exe_order > exe_high):
                         subg.remove_node(n)


### PR DESCRIPTION
Several model_viewer tests are now failing on Appveyor because networkx has bee updated to 2.0.