### PR TITLE
Metadata API changes and added a feature doc for metadata

### DIFF
--- a/openmdao/components/meta_model.py
+++ b/openmdao/components/meta_model.py
@@ -88,7 +88,7 @@ class MetaModel(ExplicitComponent):
         self._input_size += input_size
 
         train_name = 'train:%s' % name
-        self.metadata.declare(train_name, desc='Training data for %s' % name)
+        self.metadata.declare(train_name, default=None, desc='Training data for %s' % name)
         if training_data is not None:
             self.metadata[train_name] = training_data
 
@@ -135,7 +135,7 @@ class MetaModel(ExplicitComponent):
             metadata['default_surrogate'] = True
 
         train_name = 'train:%s' % name
-        self.metadata.declare(train_name, desc='Training data for %s' % name)
+        self.metadata.declare(train_name, default=None, desc='Training data for %s' % name)
         if training_data is not None:
             self.metadata[train_name] = training_data
 

--- a/openmdao/components/multifi_meta_model.py
+++ b/openmdao/components/multifi_meta_model.py
@@ -124,7 +124,8 @@ class MultiFiMetaModel(MetaModel):
         for fi in range(self._nfi):
             if fi > 0:
                 name_with_fi = 'train:' + _get_name_fi(name, fi)
-                self.metadata.declare(name_with_fi, desc='Training data for %s' % name_with_fi)
+                self.metadata.declare(
+                    name_with_fi, default=None, desc='Training data for %s' % name_with_fi)
                 self._input_sizes[fi] += input_size
 
     def add_output(self, name, val=1.0, **kwargs):
@@ -178,7 +179,8 @@ class MultiFiMetaModel(MetaModel):
         for fi in range(self._nfi):
             if fi > 0:
                 name_with_fi = 'train:' + _get_name_fi(name, fi)
-                self.metadata.declare(name_with_fi, desc='Training data for %s' % name_with_fi)
+                self.metadata.declare(
+                    name_with_fi, default=None, desc='Training data for %s' % name_with_fi)
 
     def _train(self):
         """

--- a/openmdao/core/tests/test_matmat.py
+++ b/openmdao/core/tests/test_matmat.py
@@ -159,7 +159,7 @@ class LGLFit(ExplicitComponent):
     an approximation of arclength.
     """
     def initialize(self):
-        self.metadata.declare(name='num_nodes', required=True, type_=int)
+        self.metadata.declare(name='num_nodes', type_=int)
 
     def setup(self):
         n = self.metadata['num_nodes']
@@ -188,7 +188,7 @@ class LGLFit(ExplicitComponent):
 class DefectComp(ExplicitComponent):
 
     def initialize(self):
-        self.metadata.declare(name='num_nodes', required=True, type_=int)
+        self.metadata.declare(name='num_nodes', type_=int)
 
     def setup(self):
         n = self.metadata['num_nodes']
@@ -208,7 +208,7 @@ class DefectComp(ExplicitComponent):
 class ArcLengthFunction(ExplicitComponent):
 
     def initialize(self):
-        self.metadata.declare(name='num_nodes', required=True, type_=int)
+        self.metadata.declare(name='num_nodes', type_=int)
 
     def setup(self):
         n = self.metadata['num_nodes']
@@ -232,7 +232,7 @@ class ArcLengthQuadrature(ExplicitComponent):
     Computes the arclength of a polynomial segment whose values are given at the LGL nodes.
     """
     def initialize(self):
-        self.metadata.declare(name='num_nodes', required=True, type_=int)
+        self.metadata.declare(name='num_nodes', type_=int)
 
     def setup(self):
         n = self.metadata['num_nodes']
@@ -303,7 +303,7 @@ class Phase(Group):
 class Summer(ExplicitComponent):
 
     def initialize(self):
-        self.metadata.declare('n_phases', type_=int, required=True)
+        self.metadata.declare('n_phases', type_=int)
 
     def setup(self):
         self.add_output('total_arc_length')

--- a/openmdao/docs/feature_reference/core_features/defining_components/index.rst
+++ b/openmdao/docs/feature_reference/core_features/defining_components/index.rst
@@ -14,3 +14,4 @@ Building Components
     distributed_comps.rst
     units.rst
     scaling.rst
+    metadata.rst

--- a/openmdao/docs/feature_reference/core_features/defining_components/metadata.rst
+++ b/openmdao/docs/feature_reference/core_features/defining_components/metadata.rst
@@ -1,0 +1,78 @@
+.. _component_metadata:
+
+********************************************
+Component metadata (arguments to components)
+********************************************
+
+Components, whether explicit or implicit, define inputs and outputs and how to map inputs to outputs.
+Often, there are incidental parameters that affect the behavior of the component
+but are not considered input variables in the sense that their values are
+computed as an output of another component.
+
+For convenience, OpenMDAO provides a way of declaring these parameters, which we call *metadata*.
+They are declared in the 'initialize' method of the user's component,
+and the values are typically passed in upon instantiation of the component.
+Metadata can be declared along with their default values and various checks for validity,
+such as a list of acceptable values or types.
+The full list of options can be found in the method signature at the bottom of this page.
+
+A simple example
+----------------
+
+A common use of metadata is to specify the shape or size of the component's input and output variables.
+
+.. embed-code::
+    openmdao.utils.tests.test_options_dictionary_feature.VectorDoublingComp
+
+.. embed-test::
+    openmdao.utils.tests.test_options_dictionary_feature.TestOptionsDictionaryFeature.test_simple
+
+In this example, 'size' is required; the first time we try to get 'size',
+we would have got an error if we
+(1) did not pass in 'size' when instantiating 'VectorDoublingComp' and
+(2) did not set its value in the code for VectorDoublingComp.
+
+Providing default values
+------------------------
+
+One reason why using metadata is convenient is that a default value can be specified,
+allowing passing the value in during component instantiation to be optional.
+
+.. embed-code::
+    openmdao.utils.tests.test_options_dictionary_feature.LinearCombinationComp
+
+.. embed-test::
+    openmdao.utils.tests.test_options_dictionary_feature.TestOptionsDictionaryFeature.test_with_default
+
+In this example, both 'a' and 'b' are optional, so it is valid to pass in 'b', but not 'b'.
+
+Specifying values and types
+---------------------------
+
+Another commonly-used metadata feature is specifying acceptable values and types.
+If only the list of acceptable values is specified,
+the default value and the value passed in must be one of these values.
+If only the list of acceptable types is specified,
+the default value and the value passed in must be an instance one of these types.
+If both the lists of acceptable values and types are specified,
+the default value and the value passed in must be one of the values OR an instance one of the types.
+This is illustrated in the following example.
+
+.. embed-code::
+    openmdao.utils.tests.test_options_dictionary_feature.UnitaryFunctionComp
+
+.. embed-test::
+    openmdao.utils.tests.test_options_dictionary_feature.TestOptionsDictionaryFeature.test_values_and_types
+
+In this example, it is convenient to specify a list of acceptable values of the 'func' metadata,
+but also to provide a valid type if it is not one of these acceptable values.
+
+
+Method Signature
+----------------
+
+.. automethod:: openmdao.utils.options_dictionary.OptionsDictionary.declare
+    :noindex:
+
+
+.. tags:: Metadata

--- a/openmdao/docs/feature_reference/core_features/defining_components/metadata.rst
+++ b/openmdao/docs/feature_reference/core_features/defining_components/metadata.rst
@@ -19,7 +19,10 @@ Alternatively, the values can be set at any time, whether in any method of the c
 (except for 'initialize') or outside of the component definition after the component is instantiated.
 Metadata can be declared along with their default values and various checks for validity,
 such as a list of acceptable values or types.
-The full list of options can be found in the method signature at the bottom of this page.
+The full list of options can be found in the method signature below.
+
+.. automethod:: openmdao.utils.options_dictionary.OptionsDictionary.declare
+    :noindex:
 
 A simple example
 ----------------
@@ -27,7 +30,7 @@ A simple example
 A common use of metadata is to specify the shape or size of the component's input and output variables.
 
 .. embed-code::
-    openmdao.utils.tests.test_options_dictionary_feature.VectorDoublingComp
+    openmdao.test_suite.components.metadata_feature_vector
 
 .. embed-test::
     openmdao.utils.tests.test_options_dictionary_feature.TestOptionsDictionaryFeature.test_simple
@@ -47,7 +50,7 @@ One reason why using metadata is convenient is that a default value can be speci
 making it optional to pass the value in during component instantiation.
 
 .. embed-code::
-    openmdao.utils.tests.test_options_dictionary_feature.LinearCombinationComp
+    openmdao.test_suite.components.metadata_feature_lincomb
 
 .. embed-test::
     openmdao.utils.tests.test_options_dictionary_feature.TestOptionsDictionaryFeature.test_with_default
@@ -67,20 +70,12 @@ the default value and the value passed in must be one of the values OR an instan
 This is illustrated in the following example.
 
 .. embed-code::
-    openmdao.utils.tests.test_options_dictionary_feature.UnitaryFunctionComp
+    openmdao.test_suite.components.metadata_feature_function
 
 .. embed-test::
     openmdao.utils.tests.test_options_dictionary_feature.TestOptionsDictionaryFeature.test_values_and_types
 
 In this example, it is convenient to specify a list of acceptable values of the 'func' metadata,
 but also to provide a valid type if it is not one of these acceptable values.
-
-
-Method Signature
-----------------
-
-.. automethod:: openmdao.utils.options_dictionary.OptionsDictionary.declare
-    :noindex:
-
 
 .. tags:: Metadata

--- a/openmdao/docs/feature_reference/core_features/defining_components/metadata.rst
+++ b/openmdao/docs/feature_reference/core_features/defining_components/metadata.rst
@@ -9,10 +9,14 @@ as well as the mapping that computes the outputs given the inputs.
 Often, however, there are incidental parameters that affect the behavior of the component
 but are not considered input variables in the sense of being computed as an output of another component.
 
-For convenience, OpenMDAO provides a way of declaring these parameters, which are referred to as *metadata*.
+OpenMDAO provides a way of declaring these parameters, which are referred to as *metadata*.
 They are declared in the 'initialize' method of the user's component,
 and the values are typically passed in upon instantiation of the component.
-Alternatively, the values can be set at any time inside or outside of the component.
+Once the values are passed in during instantiation, they are automatically set into the metadata object
+and are available for use in any method other than 'initialize'.
+
+Alternatively, the values can be set at any time, whether in any method of the component
+(except for 'initialize') or outside of the component definition after the component is instantiated.
 Metadata can be declared along with their default values and various checks for validity,
 such as a list of acceptable values or types.
 The full list of options can be found in the method signature at the bottom of this page.

--- a/openmdao/docs/feature_reference/core_features/defining_components/metadata.rst
+++ b/openmdao/docs/feature_reference/core_features/defining_components/metadata.rst
@@ -4,14 +4,15 @@
 Component metadata (arguments to components)
 ********************************************
 
-Components, whether explicit or implicit, define inputs and outputs and how to map inputs to outputs.
-Often, there are incidental parameters that affect the behavior of the component
-but are not considered input variables in the sense that their values are
-computed as an output of another component.
+The primary job of a component, whether explicit or implicit, is to define inputs and outputs,
+as well as the mapping that computes the outputs given the inputs.
+Often, however, there are incidental parameters that affect the behavior of the component
+but are not considered input variables in the sense of being computed as an output of another component.
 
-For convenience, OpenMDAO provides a way of declaring these parameters, which we call *metadata*.
+For convenience, OpenMDAO provides a way of declaring these parameters, which are referred to as *metadata*.
 They are declared in the 'initialize' method of the user's component,
 and the values are typically passed in upon instantiation of the component.
+Alternatively, the values can be set at any time inside or outside of the component.
 Metadata can be declared along with their default values and various checks for validity,
 such as a list of acceptable values or types.
 The full list of options can be found in the method signature at the bottom of this page.
@@ -29,14 +30,17 @@ A common use of metadata is to specify the shape or size of the component's inpu
 
 In this example, 'size' is required; the first time we try to get 'size',
 we would have got an error if we
-(1) did not pass in 'size' when instantiating 'VectorDoublingComp' and
-(2) did not set its value in the code for VectorDoublingComp.
+
+1. did not pass in 'size' when instantiating 'VectorDoublingComp' and
+2. did not set its value in the code for VectorDoublingComp.
+
+Not setting a default value when declaring it implies that the value must be set prior to getting it.
 
 Providing default values
 ------------------------
 
 One reason why using metadata is convenient is that a default value can be specified,
-allowing passing the value in during component instantiation to be optional.
+making it optional to pass the value in during component instantiation.
 
 .. embed-code::
     openmdao.utils.tests.test_options_dictionary_feature.LinearCombinationComp
@@ -44,7 +48,7 @@ allowing passing the value in during component instantiation to be optional.
 .. embed-test::
     openmdao.utils.tests.test_options_dictionary_feature.TestOptionsDictionaryFeature.test_with_default
 
-In this example, both 'a' and 'b' are optional, so it is valid to pass in 'b', but not 'b'.
+In this example, both 'a' and 'b' are optional, so it is valid to pass in 'a', but not 'b'.
 
 Specifying values and types
 ---------------------------

--- a/openmdao/test_suite/components/metadata_feature_function.py
+++ b/openmdao/test_suite/components/metadata_feature_function.py
@@ -1,0 +1,30 @@
+"""
+Component for a metadata feature test.
+"""
+import numpy as np
+from types import FunctionType
+
+from openmdao.api import ExplicitComponent
+
+
+class UnitaryFunctionComp(ExplicitComponent):
+
+    def initialize(self):
+        self.metadata.declare('func', values=('exp', 'cos', 'sin'), type_=FunctionType)
+
+    def setup(self):
+        self.add_input('x')
+        self.add_output('y')
+        self.declare_partials('y', 'x', method='fd')
+
+    def compute(self, inputs, outputs):
+        func = self.metadata['func']
+
+        if func == 'exp':
+            outputs['y'] = np.exp(inputs['x'])
+        elif func == 'cos':
+            outputs['y'] = np.cos(inputs['x'])
+        elif func == 'sin':
+            outputs['y'] = np.sin(inputs['x'])
+        else:
+            outputs['y'] = func(inputs['x'])

--- a/openmdao/test_suite/components/metadata_feature_lincomb.py
+++ b/openmdao/test_suite/components/metadata_feature_lincomb.py
@@ -1,0 +1,21 @@
+"""
+Component for a metadata feature test.
+"""
+import numpy as np
+
+from openmdao.api import ExplicitComponent
+
+
+class LinearCombinationComp(ExplicitComponent):
+
+    def initialize(self):
+        self.metadata.declare('a', default=1., type_=np.ScalarType)
+        self.metadata.declare('b', default=1., type_=np.ScalarType)
+
+    def setup(self):
+        self.add_input('x')
+        self.add_output('y')
+        self.declare_partials('y', 'x', val=self.metadata['a'])
+
+    def compute(self, inputs, outputs):
+        outputs['y'] = self.metadata['a'] * inputs['x'] + self.metadata['b']

--- a/openmdao/test_suite/components/metadata_feature_vector.py
+++ b/openmdao/test_suite/components/metadata_feature_vector.py
@@ -1,0 +1,22 @@
+"""
+Component for a metadata feature test.
+"""
+import numpy as np
+
+from openmdao.api import ExplicitComponent
+
+
+class VectorDoublingComp(ExplicitComponent):
+
+    def initialize(self):
+        self.metadata.declare('size', type_=int)
+
+    def setup(self):
+        size = self.metadata['size']
+
+        self.add_input('x', shape=size)
+        self.add_output('y', shape=size)
+        self.declare_partials('y', 'x', val=2., rows=np.arange(size), cols=np.arange(size))
+
+    def compute(self, inputs, outputs):
+        outputs['y'] = 2 * inputs['x']

--- a/openmdao/test_suite/groups/sin_fitter.py
+++ b/openmdao/test_suite/groups/sin_fitter.py
@@ -160,7 +160,7 @@ class LGLFit(ExplicitComponent):
     an approximation of arclength.
     """
     def initialize(self):
-        self.metadata.declare(name='num_nodes', required=True, type_=int)
+        self.metadata.declare(name='num_nodes', type_=int)
 
     def setup(self):
         n = self.metadata['num_nodes']
@@ -189,7 +189,7 @@ class LGLFit(ExplicitComponent):
 class DefectComp(ExplicitComponent):
 
     def initialize(self):
-        self.metadata.declare(name='num_nodes', required=True, type_=int)
+        self.metadata.declare(name='num_nodes', type_=int)
 
     def setup(self):
         n = self.metadata['num_nodes']
@@ -209,7 +209,7 @@ class DefectComp(ExplicitComponent):
 class ArcLengthFunction(ExplicitComponent):
 
     def initialize(self):
-        self.metadata.declare(name='num_nodes', required=True, type_=int)
+        self.metadata.declare(name='num_nodes', type_=int)
 
     def setup(self):
         n = self.metadata['num_nodes']
@@ -233,7 +233,7 @@ class ArcLengthQuadrature(ExplicitComponent):
     Computes the arclength of a polynomial segment whose values are given at the LGL nodes.
     """
     def initialize(self):
-        self.metadata.declare(name='num_nodes', required=True, type_=int)
+        self.metadata.declare(name='num_nodes', type_=int)
 
     def setup(self):
         n = self.metadata['num_nodes']

--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -94,13 +94,13 @@ class OptionsDictionary(object):
 
     def declare(self, name, default=null_object, values=None, type_=None, desc='',
                 upper=None, lower=None, is_valid=None):
-        """
+        r"""
         Declare an option.
 
         The value of the option must satisfy the following:
-        1. If values and not type_ was given when declaring, value must be in values.
-        2. If type_ and not values was given when declaring, value must be an instance of type_.
-        3. If values and type_ were given when declaring, either of the above must be true.
+        1. If values and not type was given when declaring, value must be in values.
+        2. If type and not values was given when declaring, value must be an instance of type.
+        3. If values and type were given when declaring, either of the above must be true.
 
         Parameters
         ----------

--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -2,6 +2,17 @@
 from __future__ import division, print_function
 
 
+class Null(object):
+    """
+    Dummy class instantiated to check whether the default argument is given.
+    """
+
+    pass
+
+
+null_object = Null()
+
+
 class OptionsDictionary(object):
     """
     Dictionary with pre-declaration of keys for value-checking and default values.
@@ -81,7 +92,7 @@ class OptionsDictionary(object):
         if is_valid is not None and not is_valid(value):
             raise ValueError("Function is_valid returns False for {}.".format(name))
 
-    def declare(self, name, default=None, values=None, type_=None, desc='', required=False,
+    def declare(self, name, default=null_object, values=None, type_=None, desc='',
                 upper=None, lower=None, is_valid=None):
         """
         Declare an option.
@@ -95,17 +106,14 @@ class OptionsDictionary(object):
         ----------
         name : str
             Name of the option.
-        default : object or None
+        default : object or Null
             Optional default value that must be valid under the above 3 conditions.
         values : set or list or tuple or None
             Optional list of acceptable option values.
-        type_ : type or tuple of types or None
+        type_ : type or set/list/tuple of types or None
             Optional type or list of acceptable option types.
         desc : str
             Optional description of the option.
-        required : bool
-            Whether the key must be set prior to reading its value
-            (as opposed to just using the default).
         upper : float or None
             Maximum allowable value.
         lower : float or None
@@ -115,8 +123,10 @@ class OptionsDictionary(object):
         """
         if values is not None and not isinstance(values, (set, list, tuple)):
             raise TypeError("'values' must be of type None, list, or tuple - not %s." % values)
-        if type_ is not None and not isinstance(type_, (type, tuple)):
+        if type_ is not None and not isinstance(type_, (type, set, list, tuple)):
             raise TypeError("'type_' must be None, a type or a tuple  - not %s." % type_)
+
+        default_provided = default != null_object
 
         self._dict[name] = {
             'value': default,
@@ -126,11 +136,11 @@ class OptionsDictionary(object):
             'upper': upper,
             'lower': lower,
             'is_valid': is_valid,
-            'has_been_set': not required,  # If not required, has_been_set is True from the getgo
+            'has_been_set': default_provided,
         }
 
         # If a default is given, check for validity
-        if default is not None:
+        if default_provided:
             self._assert_valid(name, default)
 
     def update(self, in_dict):

--- a/openmdao/utils/tests/test_options_dictionary.py
+++ b/openmdao/utils/tests/test_options_dictionary.py
@@ -45,15 +45,6 @@ class TestOptionsDict(unittest.TestCase):
         self.dict['test3'] = 'a'
         self.assertEqual(self.dict['test3'], 'a')
 
-    def test_required(self):
-        self.dict.declare('test', required=True)
-
-        with self.assertRaises(RuntimeError) as context:
-            self.dict['test']
-
-        expected_msg = "Entry 'test' is required but has not been set."
-        self.assertEqual(expected_msg, str(context.exception))
-
     def test_isvalid(self):
         self.dict.declare('even_test', type_=int, is_valid=lambda x: x%2 == 0)
         self.dict['even_test'] = 2

--- a/openmdao/utils/tests/test_options_dictionary_feature.py
+++ b/openmdao/utils/tests/test_options_dictionary_feature.py
@@ -5,107 +5,62 @@ import numpy as np
 from openmdao.devtools.testutil import assert_rel_error
 
 
-class VectorDoublingComp(ExplicitComponent):
-
-    def initialize(self):
-        self.metadata.declare('size', type_=int)
-
-    def setup(self):
-        size = self.metadata['size']
-
-        self.add_input('x', shape=size)
-        self.add_output('y', shape=size)
-        self.declare_partials('y', 'x', val=2., rows=np.arange(size), cols=np.arange(size))
-
-    def compute(self, inputs, outputs):
-        outputs['y'] = 2 * inputs['x']
-
-
-class LinearCombinationComp(ExplicitComponent):
-
-    def initialize(self):
-        self.metadata.declare('a', default=1., type_=(int, float))
-        self.metadata.declare('b', default=1., type_=(int, float))
-
-    def setup(self):
-        self.add_input('x')
-        self.add_output('y')
-        self.declare_partials('y', 'x', val=self.metadata['a'])
-
-    def compute(self, inputs, outputs):
-        outputs['y'] = self.metadata['a'] * inputs['x'] + self.metadata['b']
-
-
-class UnitaryFunctionComp(ExplicitComponent):
-
-    def initialize(self):
-        from types import FunctionType
-
-        self.metadata.declare('func', values=('exp', 'cos', 'sin'), type_=FunctionType)
-
-    def setup(self):
-        self.add_input('x')
-        self.add_output('y')
-        self.declare_partials('y', 'x', method='fd')
-
-    def compute(self, inputs, outputs):
-        func = self.metadata['func']
-
-        if func == 'exp':
-            outputs['y'] = np.exp(inputs['x'])
-        elif func == 'cos':
-            outputs['y'] = np.cos(inputs['x'])
-        elif func == 'sin':
-            outputs['y'] = np.sin(inputs['x'])
-        else:
-            outputs['y'] = func(inputs['x'])
-
-
 class TestOptionsDictionaryFeature(unittest.TestCase):
 
     def test_simple(self):
-        from openmdao.api import Problem
+        from openmdao.api import Problem, IndepVarComp
+        from openmdao.test_suite.components.metadata_feature_vector import VectorDoublingComp
 
         prob = Problem()
-        prob.model = VectorDoublingComp(size=3)
+        prob.model.add_subsystem('input_comp', IndepVarComp('x', shape=3))
+        prob.model.add_subsystem('main_comp', VectorDoublingComp(size=3))
+        prob.model.connect('input_comp.x', 'main_comp.x')
         prob.setup()
 
-        prob['x'] = [1., 2., 3.]
+        prob['input_comp.x'] = [1., 2., 3.]
         prob.run_model()
-        assert_rel_error(self, prob['y'], [2., 4., 6.])
+        assert_rel_error(self, prob['main_comp.y'], [2., 4., 6.])
 
     def test_with_default(self):
-        from openmdao.api import Problem
+        from openmdao.api import Problem, IndepVarComp
+        from openmdao.test_suite.components.metadata_feature_lincomb import LinearCombinationComp
 
         prob = Problem()
-        prob.model = LinearCombinationComp(a=2.)
+        prob.model.add_subsystem('input_comp', IndepVarComp('x'))
+        prob.model.add_subsystem('main_comp', LinearCombinationComp(a=2.))
+        prob.model.connect('input_comp.x', 'main_comp.x')
         prob.setup()
 
-        prob['x'] = 3
+        prob['input_comp.x'] = 3
         prob.run_model()
-        self.assertEqual(prob['y'], 7.)
+        self.assertEqual(prob['main_comp.y'], 7.)
 
     def test_values_and_types(self):
-        from openmdao.api import Problem
+        from openmdao.api import Problem, IndepVarComp
+        from openmdao.test_suite.components.metadata_feature_function import UnitaryFunctionComp
 
         prob = Problem()
-        prob.model = UnitaryFunctionComp(func='cos')
+        prob.model.add_subsystem('input_comp', IndepVarComp('x'))
+        prob.model.add_subsystem('main_comp', UnitaryFunctionComp(func='cos'))
+        prob.model.connect('input_comp.x', 'main_comp.x')
         prob.setup()
 
-        prob['x'] = 0.
+        prob['input_comp.x'] = 0.
         prob.run_model()
-        self.assertEqual(prob['y'], 1.)
+        self.assertEqual(prob['main_comp.y'], 1.)
 
         def myfunc(x):
             return x ** 2 + 2
 
         prob = Problem()
-        prob.model = UnitaryFunctionComp(func=myfunc)
+        prob.model.add_subsystem('input_comp', IndepVarComp('x'))
+        prob.model.add_subsystem('main_comp', UnitaryFunctionComp(func=myfunc))
+        prob.model.connect('input_comp.x', 'main_comp.x')
         prob.setup()
 
-        prob['x'] = 2.
+        prob['input_comp.x'] = 2.
         prob.run_model()
-        self.assertEqual(prob['y'], 6.)
+        self.assertEqual(prob['main_comp.y'], 6.)
 
 
 if __name__ == "__main__":

--- a/openmdao/utils/tests/test_options_dictionary_feature.py
+++ b/openmdao/utils/tests/test_options_dictionary_feature.py
@@ -1,0 +1,112 @@
+from openmdao.api import OptionsDictionary, ExplicitComponent
+import unittest
+from six import PY3, assertRegex
+import numpy as np
+from openmdao.devtools.testutil import assert_rel_error
+
+
+class VectorDoublingComp(ExplicitComponent):
+
+    def initialize(self):
+        self.metadata.declare('size', type_=int)
+
+    def setup(self):
+        size = self.metadata['size']
+
+        self.add_input('x', shape=size)
+        self.add_output('y', shape=size)
+        self.declare_partials('y', 'x', val=2., rows=np.arange(size), cols=np.arange(size))
+
+    def compute(self, inputs, outputs):
+        outputs['y'] = 2 * inputs['x']
+
+
+class LinearCombinationComp(ExplicitComponent):
+
+    def initialize(self):
+        self.metadata.declare('a', default=1., type_=(int, float))
+        self.metadata.declare('b', default=1., type_=(int, float))
+
+    def setup(self):
+        self.add_input('x')
+        self.add_output('y')
+        self.declare_partials('y', 'x', val=self.metadata['a'])
+
+    def compute(self, inputs, outputs):
+        outputs['y'] = self.metadata['a'] * inputs['x'] + self.metadata['b']
+
+
+class UnitaryFunctionComp(ExplicitComponent):
+
+    def initialize(self):
+        from types import FunctionType
+
+        self.metadata.declare('func', values=('exp', 'cos', 'sin'), type_=FunctionType)
+
+    def setup(self):
+        self.add_input('x')
+        self.add_output('y')
+        self.declare_partials('y', 'x', method='fd')
+
+    def compute(self, inputs, outputs):
+        func = self.metadata['func']
+
+        if func == 'exp':
+            outputs['y'] = np.exp(inputs['x'])
+        elif func == 'cos':
+            outputs['y'] = np.cos(inputs['x'])
+        elif func == 'sin':
+            outputs['y'] = np.sin(inputs['x'])
+        else:
+            outputs['y'] = func(inputs['x'])
+
+
+class TestOptionsDictionaryFeature(unittest.TestCase):
+
+    def test_simple(self):
+        from openmdao.api import Problem
+
+        prob = Problem()
+        prob.model = VectorDoublingComp(size=3)
+        prob.setup()
+
+        prob['x'] = [1., 2., 3.]
+        prob.run_model()
+        assert_rel_error(self, prob['y'], [2., 4., 6.])
+
+    def test_with_default(self):
+        from openmdao.api import Problem
+
+        prob = Problem()
+        prob.model = LinearCombinationComp(a=2.)
+        prob.setup()
+
+        prob['x'] = 3
+        prob.run_model()
+        self.assertEqual(prob['y'], 7.)
+
+    def test_values_and_types(self):
+        from openmdao.api import Problem
+
+        prob = Problem()
+        prob.model = UnitaryFunctionComp(func='cos')
+        prob.setup()
+
+        prob['x'] = 0.
+        prob.run_model()
+        self.assertEqual(prob['y'], 1.)
+
+        def myfunc(x):
+            return x ** 2 + 2
+
+        prob = Problem()
+        prob.model = UnitaryFunctionComp(func=myfunc)
+        prob.setup()
+
+        prob['x'] = 2.
+        prob.run_model()
+        self.assertEqual(prob['y'], 6.)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The API is documented in the new feature doc, but here's a summary of the API changes:
- The required argument is now gone. It was redundant because it is required if default is not given and it's not required if default wasn't specified
- The default value of `default` is now an instance of a dummy Null class, so if the default was assumed to be None in the past, the metadata must be declared with an explicit, `declare=None`