### PR TITLE
autodetection of input and/or output scaling

### DIFF
--- a/openmdao/components/deprecated_component.py
+++ b/openmdao/components/deprecated_component.py
@@ -151,15 +151,19 @@ class Component(BaseComponent):
         """
         Compute residuals.
         """
-        self._scale_vec(self._inputs, 'input', 'phys')
-        self._scale_vec(self._outputs, 'output', 'phys')
-        self._scale_vec(self._residuals, 'residual', 'phys')
+        if self._has_input_scaling:
+            self._scale_vec(self._inputs, 'input', 'phys')
+        if self._has_output_scaling:
+            self._scale_vec(self._outputs, 'output', 'phys')
+            self._scale_vec(self._residuals, 'residual', 'phys')
 
         self.apply_nonlinear(self._inputs, self._outputs, self._residuals)
 
-        self._scale_vec(self._inputs, 'input', 'norm')
-        self._scale_vec(self._outputs, 'output', 'norm')
-        self._scale_vec(self._residuals, 'residual', 'norm')
+        if self._has_input_scaling:
+            self._scale_vec(self._inputs, 'input', 'norm')
+        if self._has_output_scaling:
+            self._scale_vec(self._outputs, 'output', 'norm')
+            self._scale_vec(self._residuals, 'residual', 'norm')
 
     def _solve_nonlinear(self):
         """
@@ -179,15 +183,19 @@ class Component(BaseComponent):
         if self._nonlinear_solver is not None:
             self._nonlinear_solver.solve()
         else:
-            self._scale_vec(self._inputs, 'input', 'phys')
-            self._scale_vec(self._outputs, 'output', 'phys')
-            self._scale_vec(self._residuals, 'residual', 'phys')
+            if self._has_input_scaling:
+                self._scale_vec(self._inputs, 'input', 'phys')
+            if self._has_output_scaling:
+                self._scale_vec(self._outputs, 'output', 'phys')
+                self._scale_vec(self._residuals, 'residual', 'phys')
 
             self.solve_nonlinear(self._inputs, self._outputs, self._residuals)
 
-            self._scale_vec(self._inputs, 'input', 'norm')
-            self._scale_vec(self._outputs, 'output', 'norm')
-            self._scale_vec(self._residuals, 'residual', 'norm')
+            if self._has_input_scaling:
+                self._scale_vec(self._inputs, 'input', 'norm')
+            if self._has_output_scaling:
+                self._scale_vec(self._outputs, 'output', 'norm')
+                self._scale_vec(self._residuals, 'residual', 'norm')
 
     def _apply_linear(self, vec_names, rel_systems, mode, scope_out=None, scope_in=None):
         """

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -494,9 +494,9 @@ class Component(System):
             self._has_output_scaling |= np.any(ref0 != 0.0)
 
         if np.isscalar(res_ref):
-            self._has_resid_scaling |= res_ref != 1.0
+            self._has_output_scaling |= res_ref != 1.0
         else:
-            self._has_resid_scaling |= np.any(res_ref != 1.0)
+            self._has_output_scaling |= np.any(res_ref != 1.0)
 
         ref = format_as_float_or_array('ref', ref, flatten=True)
         ref0 = format_as_float_or_array('ref0', ref0, flatten=True)

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -149,6 +149,7 @@ class Component(System):
         else:
             prefix = ''
 
+        # the following metadata will be accessible for vars on all procs
         meta_names = {
             'input': ('units', 'shape', 'size', 'var_set'),
             'output': ('units', 'shape', 'size', 'var_set', 'ref', 'ref0', 'distributed'),
@@ -340,6 +341,8 @@ class Component(System):
         # units: taken as is
         metadata['units'] = units
 
+        self._has_input_scaling |= units is not None
+
         # desc: taken as is
         metadata['desc'] = desc
 
@@ -481,6 +484,9 @@ class Component(System):
             if not np.isscalar(item) and \
                np.atleast_1d(item).shape != metadata['shape']:
                 raise ValueError('The %s argument has the wrong shape' % msg)
+
+        self._has_output_scaling |= (ref, ref0) != (1.0, 0.0)
+        self._has_resid_scaling |= res_ref != 1.0
 
         ref = format_as_float_or_array('ref', ref, flatten=True)
         ref0 = format_as_float_or_array('ref0', ref0, flatten=True)

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -150,9 +150,10 @@ class Component(System):
             prefix = ''
 
         # the following metadata will be accessible for vars on all procs
-        meta_names = {
+        global_meta_names = {
             'input': ('units', 'shape', 'size', 'var_set'),
-            'output': ('units', 'shape', 'size', 'var_set', 'ref', 'ref0', 'distributed'),
+            'output': ('units', 'shape', 'size', 'var_set',
+                       'ref', 'ref0', 'res_ref', 'distributed'),
         }
 
         for type_ in ['input', 'output']:
@@ -171,7 +172,7 @@ class Component(System):
                 # Compute allprocs_abs2meta
                 allprocs_abs2meta[type_][abs_name] = {
                     meta_name: metadata[meta_name]
-                    for meta_name in meta_names[type_]
+                    for meta_name in global_meta_names[type_]
                 }
 
                 # Compute abs2meta

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -706,7 +706,7 @@ class Group(System):
                         needs_input_scaling = np.any(res_ref != 1.0)
 
                 # if units are defined and different, we need input scaling
-                if needs_input_scaling or (in_units and in_units != out_units):
+                if needs_input_scaling or (in_units and out_units and in_units != out_units):
                     self._has_input_scaling = True
 
         # Now that both implicit & explicit connections have been added,

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -658,6 +658,12 @@ class Group(System):
         else:
             path_len = len(pathname) + 1
 
+        allprocs_abs2meta_out = self._var_allprocs_abs2meta['output']
+        allprocs_abs2meta_in = self._var_allprocs_abs2meta['input']
+
+        # Check input/output units here, and set _has_input_scaling
+        # to True for this Group if units are defined and different, or if
+        # ref or ref0 are defined for the output.
         for abs_in, abs_out in iteritems(global_abs_in2out):
             # First, check that this system owns both the input and output.
             if abs_in[:len(pathname)] == pathname and abs_out[:len(pathname)] == pathname:
@@ -667,15 +673,40 @@ class Group(System):
                 if out_subsys != in_subsys:
                     abs_in2out[abs_in] = abs_out
 
+            # if connected output has scaling then we need input scaling
+            if not self._has_input_scaling:
+                out_units = allprocs_abs2meta_out[abs_out]['units']
+                in_units = allprocs_abs2meta_in[abs_in]['units']
+
+                needs_input_scaling = False
+                ref = allprocs_abs2meta_out[abs_out]['ref']
+                if np.isscalar(ref):
+                    needs_input_scaling = ref != 1.0
+                else:
+                    needs_input_scaling = np.any(ref != 1.0)
+
+                if not needs_input_scaling:
+                    ref0 = allprocs_abs2meta_out[abs_out]['ref0']
+                    if np.isscalar(ref0):
+                        needs_input_scaling = ref0 != 0.0
+                    else:
+                        needs_input_scaling = np.any(ref0 != 0.0)
+
+                if not needs_input_scaling:
+                    res_ref = allprocs_abs2meta_out[abs_out]['res_ref']
+                    if np.isscalar(res_ref):
+                        needs_input_scaling = res_ref != 1.0
+                    else:
+                        needs_input_scaling = np.any(res_ref != 1.0)
+
+                # if units are defined and different, we need input scaling
+                if needs_input_scaling or (in_units and in_units != out_units):
+                    self._has_input_scaling = True
+
         # Now that both implicit & explicit connections have been added,
         # check unit/shape compatibility, but only for connections that are
         # either owned by (implicit) or declared by (explicit) this Group.
         # This way, we don't repeat the error checking in multiple groups.
-        # Also, since we're checking input/output units here, set _has_input_scaling
-        # to True for the target system if units are defined and different, or if
-        # ref or ref0 are defined for the output.
-        allprocs_abs2meta_out = self._var_allprocs_abs2meta['output']
-        allprocs_abs2meta_in = self._var_allprocs_abs2meta['input']
         abs2meta_in = self._var_abs2meta['input']
         abs2meta_out = self._var_abs2meta['output']
 
@@ -694,25 +725,6 @@ class Group(System):
                                        " incompatible with input units of "
                                        "'%s' for '%s'." %
                                        (out_units, abs_out, in_units, abs_in))
-
-                # if connected output has scaling then we need input scaling
-                needs_input_scaling = False
-                ref = allprocs_abs2meta_out[abs_out]['ref']
-                if np.isscalar(ref):
-                    needs_input_scaling = ref != 1.0
-                else:
-                    needs_input_scaling = np.any(ref != 1.0)
-
-                ref0 = allprocs_abs2meta_out[abs_out]['ref0']
-                if np.isscalar(ref0):
-                    needs_input_scaling = ref0 != 0.0
-                else:
-                    needs_input_scaling = np.any(ref0 != 0.0)
-
-                # if units are defined and different, we need input scaling
-                if needs_input_scaling or (in_units and in_units != out_units):
-                    in_subsys = abs_in[path_len:].split('.', 1)[0]
-                    getattr(self, in_subsys)._has_input_scaling = True
             elif in_units is not None:
                 warnings.warn("Input '%s' with units of '%s' is "
                               "connected to output '%s' which has "

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -686,30 +686,34 @@ class Group(System):
                 out_units = allprocs_abs2meta_out[abs_out]['units']
                 in_units = allprocs_abs2meta_in[abs_in]['units']
 
-                needs_input_scaling = False
-                ref = allprocs_abs2meta_out[abs_out]['ref']
-                if np.isscalar(ref):
-                    needs_input_scaling = ref != 1.0
-                else:
-                    needs_input_scaling = np.any(ref != 1.0)
+                # if units are defined and different, we need input scaling.
+                needs_input_scaling = (in_units and out_units and in_units != out_units)
 
+                # we also need it if a connected output has any scaling.
                 if not needs_input_scaling:
-                    ref0 = allprocs_abs2meta_out[abs_out]['ref0']
-                    if np.isscalar(ref0):
-                        needs_input_scaling = ref0 != 0.0
-                    else:
-                        needs_input_scaling = np.any(ref0 != 0.0)
+                    out_meta = allprocs_abs2meta_out[abs_out]
 
-                if not needs_input_scaling:
-                    res_ref = allprocs_abs2meta_out[abs_out]['res_ref']
-                    if np.isscalar(res_ref):
-                        needs_input_scaling = res_ref != 1.0
+                    ref = out_meta['ref']
+                    if np.isscalar(ref):
+                        needs_input_scaling = ref != 1.0
                     else:
-                        needs_input_scaling = np.any(res_ref != 1.0)
+                        needs_input_scaling = np.any(ref != 1.0)
 
-                # if units are defined and different, we need input scaling
-                if needs_input_scaling or (in_units and out_units and in_units != out_units):
-                    self._has_input_scaling = True
+                    if not needs_input_scaling:
+                        ref0 = out_meta['ref0']
+                        if np.isscalar(ref0):
+                            needs_input_scaling = ref0 != 0.0
+                        else:
+                            needs_input_scaling = np.any(ref0)
+
+                        if not needs_input_scaling:
+                            res_ref = out_meta['res_ref']
+                            if np.isscalar(res_ref):
+                                needs_input_scaling = res_ref != 1.0
+                            else:
+                                needs_input_scaling = np.any(res_ref != 1.0)
+
+                self._has_input_scaling = needs_input_scaling
 
         # Now that both implicit & explicit connections have been added,
         # check unit/shape compatibility, but only for connections that are

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1239,6 +1239,8 @@ class System(object):
         for vec_name in self._lin_rel_vec_name_list:
             vector_class = root_vectors['residual', 'phys'][vec_name][0].__class__
             relvars, _ = self._relevant[vec_name]['@all']
+            rel_ins = relvars['input']
+            rel_outs = relvars['output']
 
             for key in vecs:
                 root = root_vectors[key][vec_name]
@@ -1282,17 +1284,17 @@ class System(object):
                 vecs['residual', 'norm'][vec_name][1]._views[abs_name][:] = 1.0 / res_ref
 
             for abs_in, abs_out in iteritems(self._conn_abs_in2out):
-                if abs_in not in abs2meta_in or abs_in not in relvars['input']:
+                if abs_in not in abs2meta_in or abs_in not in rel_ins or abs_out not in rel_outs:
                     continue
 
                 meta_out = allprocs_abs2meta_out[abs_out]
                 meta_in = abs2meta_in[abs_in]
 
                 shape_out = meta_out['shape']
-                units_out = meta_out['units']
-                distrib_out = meta_out['distributed']
                 shape_in = meta_in['shape']
                 units_in = meta_in['units']
+                units_out = meta_out['units']
+                distrib_out = meta_out['distributed']
 
                 ref = meta_out['ref']
                 ref0 = meta_out['ref0']

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -242,6 +242,12 @@ class System(object):
     #
     _has_guess : bool
         True if this system has or contains a system with a `guess_nonlinear` method defined.
+    _has_output_scaling : bool
+        True if this system has output scaling.
+    _has_resid_scaling : bool
+        True if this system has residual scaling.
+    _has_input_scaling : bool
+        True if this system has input scaling.
     #
     _owning_rank : {'input': {}, 'output': {}}
         Dict mapping var name to the lowest rank where that variable is local.
@@ -350,6 +356,9 @@ class System(object):
         self.metadata.update(kwargs)
 
         self._has_guess = False
+        self._has_output_scaling = False
+        self._has_resid_scaling = False
+        self._has_input_scaling = False
 
     def _check_reconf(self):
         """

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1491,16 +1491,17 @@ class System(object):
             If int, perform a partial transfer for linear Gauss--Seidel.
         """
         vec_inputs = self._vectors['input'][vec_name]
-        vec_outputs = self._vectors['output'][vec_name]
 
         if mode == 'fwd':
-            direction = ('norm', 'phys')
+            self._scale_vec(vec_inputs, 'input', 'norm')
+            self._transfers[vec_name][mode, isub].transfer(vec_inputs,
+                                                           self._vectors['output'][vec_name], mode)
+            self._scale_vec(vec_inputs, 'input', 'phys')
         else:  # rev
-            direction = ('phys', 'norm')
-
-        self._scale_vec(vec_inputs, 'input', direction[0])
-        self._transfers[vec_name][mode, isub].transfer(vec_inputs, vec_outputs, mode)
-        self._scale_vec(vec_inputs, 'input', direction[1])
+            self._scale_vec(vec_inputs, 'input', 'phys')
+            self._transfers[vec_name][mode, isub].transfer(vec_inputs,
+                                                           self._vectors['output'][vec_name], mode)
+            self._scale_vec(vec_inputs, 'input', 'norm')
 
     def get_req_procs(self):
         """

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1504,15 +1504,27 @@ class System(object):
         vec_inputs = self._vectors['input'][vec_name]
 
         if mode == 'fwd':
-            self._scale_vec(vec_inputs, 'input', 'norm')
-            self._transfers[vec_name][mode, isub].transfer(vec_inputs,
-                                                           self._vectors['output'][vec_name], mode)
-            self._scale_vec(vec_inputs, 'input', 'phys')
+            if self._has_input_scaling:
+                self._scale_vec(vec_inputs, 'input', 'norm')
+                self._transfers[vec_name][mode, isub].transfer(vec_inputs,
+                                                               self._vectors['output'][vec_name],
+                                                               mode)
+                self._scale_vec(vec_inputs, 'input', 'phys')
+            else:
+                self._transfers[vec_name][mode, isub].transfer(vec_inputs,
+                                                               self._vectors['output'][vec_name],
+                                                               mode)
         else:  # rev
-            self._scale_vec(vec_inputs, 'input', 'phys')
-            self._transfers[vec_name][mode, isub].transfer(vec_inputs,
-                                                           self._vectors['output'][vec_name], mode)
-            self._scale_vec(vec_inputs, 'input', 'norm')
+            if self._has_input_scaling:
+                self._scale_vec(vec_inputs, 'input', 'phys')
+                self._transfers[vec_name][mode, isub].transfer(vec_inputs,
+                                                               self._vectors['output'][vec_name],
+                                                               mode)
+                self._scale_vec(vec_inputs, 'input', 'norm')
+            else:
+                self._transfers[vec_name][mode, isub].transfer(vec_inputs,
+                                                               self._vectors['output'][vec_name],
+                                                               mode)
 
     def get_req_procs(self):
         """

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -791,7 +791,9 @@ class System(object):
                                               force_alloc_complex=force_alloc_complex)
         self._setup_vectors(root_vectors, resize=resize)
         self._setup_bounds(*self._get_bounds_root_vectors(vector_class, initial), resize=resize)
-        self._setup_scaling(self._get_scaling_root_vectors(vector_class, initial), resize=resize)
+        if self._has_input_scaling or self._has_output_scaling:
+            self._setup_scaling(self._get_scaling_root_vectors(vector_class, initial),
+                                resize=resize)
 
         # Transfers do not require recursion, but they have to be set up after the vector setup.
         self._setup_transfers(recurse=recurse)

--- a/openmdao/devtools/run_test.py
+++ b/openmdao/devtools/run_test.py
@@ -24,11 +24,14 @@ def run_test():
     """
 
     sys.path.append('.')
-    testspec = sys.argv[1]
+    if len(sys.argv) > 1:
+        testspec = sys.argv[1]
+        parts = testspec.split(':')
 
-    parts = testspec.split(':')
-    if len(parts) != 2:
-        print('Usage: run_test my_file_path:my_test_case.test_func_name')
+    if len(sys.argv) != 2 or len(parts) != 2:
+        print('Usage: run_test my_file_path:my_test_case.test_func_name\n'
+              '            OR\n'
+              '       run_test my_file_path:test_func_name')
         sys.exit(-1)
 
     modpath, funcpath = parts

--- a/openmdao/devtools/run_test.py
+++ b/openmdao/devtools/run_test.py
@@ -1,0 +1,56 @@
+"""
+This allows you to run a specific test function by itself from an importable module.
+
+The function can be either a method of a unittest.TestCase subclass, or just a function defined
+at module level.  This is useful when running an individual test under mpirun for debugging
+purposes.
+
+To specify the test to run, use the following forms:
+
+<modpath>:<testcase name>.<funcname>   OR   <modpath>:<funcname>
+
+for example:
+
+    mpirun -n 4 run_test mypackage.mysubpackage.mymod:MyTestCase.test_foo
+
+"""
+from __future__ import print_function
+
+import sys
+
+def run_test():
+    """
+    Run individual test(s).
+    """
+
+    sys.path.append('.')
+    testspec = sys.argv[1]
+
+    parts = testspec.split(':')
+    if len(parts) != 2:
+        print('Usage: run_test my_file_path:my_test_case.test_func_name')
+        sys.exit(-1)
+
+    modpath, funcpath = parts
+
+    __import__(modpath)
+    mod = sys.modules[modpath]
+
+    parts = funcpath.split('.', 1)
+    if len(parts) == 2:
+        tcase_name, method_name = parts
+        testcase = getattr(mod, tcase_name)(methodName=method_name)
+        setup = getattr(testcase, 'setUp', None)
+        if setup is not None:
+            setup()
+        getattr(testcase, method_name)()
+        teardown = getattr(testcase, 'tearDown', None)
+        if teardown:
+            teardown()
+    else:
+        funcname = parts[0]
+        getattr(mod, funcname)()
+
+
+if __name__ == '__main__':
+    run_test()

--- a/openmdao/jacobians/jacobian.py
+++ b/openmdao/jacobians/jacobian.py
@@ -174,11 +174,12 @@ class Jacobian(object):
             subjac = np.atleast_1d(subjac)
             safe_dtype = np.promote_types(subjac.dtype, float)
             subjac = subjac.astype(safe_dtype, copy=False)
-            if abs_key not in self._subjacs_info:
-                rows = None
-            else:
+            if abs_key in self._subjacs_info:
                 subjac_info = self._subjacs_info[abs_key][0]
                 rows = subjac_info['rows']
+            else:
+                rows = None
+
             if rows is None:
                 # Dense subjac
                 shape = self._abs_key2shape(abs_key)

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -383,8 +383,7 @@ class SqliteRecorder(BaseRecorder):
         """
         # Cannot handle PETScVector yet
         from openmdao.api import PETScVector
-        if isinstance(object_requesting_recording._scaling_vecs[('input', 'norm')]['linear'][0],
-                      PETScVector):
+        if isinstance(object_requesting_recording._outputs, PETScVector):
             return  # Cannot handle PETScVector yet
 
         scaling_factors = pickle.dumps(object_requesting_recording._scaling_vecs,

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -368,7 +368,7 @@ class SqliteRecorder(BaseRecorder):
         """
         # Cannot handle PETScVector yet
         from openmdao.api import PETScVector
-        if isinstance(object_requesting_recording._scaling_vecs[('input', 'norm0')]['linear'],
+        if isinstance(object_requesting_recording._scaling_vecs[('input', 'norm')]['linear'][0],
                       PETScVector):
             return  # Cannot handle PETScVector yet
 

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -86,7 +86,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         model = self.prob.model = Group()
 
         model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0]), ref=2.0), promotes=['z'])
 
         mda = model.add_subsystem('mda', Group(), promotes=['x', 'z', 'y1', 'y2'])
         mda.linear_solver = ScipyIterativeSolver()
@@ -361,7 +361,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         )
         assert_rel_error(
                         self, cr.system_metadata['root'][('output', 'phys')]['nonlinear'][1]._views_flat['pz.z'],
-                        [1.0, 1.0], 1.0e-3)
+                        [2.0, 2.0], 1.0e-3)
 
     def test_reading_solver_metadata(self):
         self.setup_sellar_model()

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -360,7 +360,7 @@ class TestSqliteCaseReader(unittest.TestCase):
                 sorted(['root', 'mda.d1', 'pz'])
         )
         assert_rel_error(
-                        self, cr.system_metadata['root'][('output', 'phys1')]['nonlinear']._views_flat['pz.z'],
+                        self, cr.system_metadata['root'][('output', 'phys')]['nonlinear'][1]._views_flat['pz.z'],
                         [1.0, 1.0], 1.0e-3)
 
     def test_reading_solver_metadata(self):

--- a/openmdao/vectors/default_vector.py
+++ b/openmdao/vectors/default_vector.py
@@ -63,6 +63,8 @@ class DefaultTransfer(Transfer):
         out_inds = self._out_inds
 
         if mode == 'fwd':
+            do_complex = in_vec._vector_info._under_complex_step and out_vec._alloc_complex
+
             for key in in_inds:
                 in_set_name, out_set_name = key
                 # this works whether the vecs have multi columns or not due to broadcasting
@@ -71,11 +73,11 @@ class DefaultTransfer(Transfer):
 
                 # Imaginary transfer
                 # (for CS, so only need in fwd)
-                if in_vec._vector_info._under_complex_step and out_vec._alloc_complex:
+                if do_complex:
                     in_vec._imag_data[in_set_name][in_inds[key]] = \
                         out_vec._imag_data[out_set_name][out_inds[key]]
 
-        elif mode == 'rev':
+        else:  # rev
             for key in in_inds:
                 in_set_name, out_set_name = key
                 np.add.at(

--- a/openmdao/vectors/default_vector.py
+++ b/openmdao/vectors/default_vector.py
@@ -440,7 +440,7 @@ class DefaultVector(Vector):
         """
         if self._ncol == 1:
             for set_name, data in iteritems(self._data):
-                data[:] *= vec._data[set_name]
+                data *= vec._data[set_name]
         else:
             for set_name, data in iteritems(self._data):
                 data *= vec._data[set_name][:, np.newaxis]

--- a/openmdao/vectors/vector.py
+++ b/openmdao/vectors/vector.py
@@ -223,7 +223,7 @@ class Vector(object):
         """
         if new_array is None:
             ncol = self._ncol
-            new_array = np.zeros(self._length) if ncol == 1 else np.zeros((self._length, ncol))
+            new_array = np.empty(self._length) if ncol == 1 else np.zeros((self._length, ncol))
 
         for set_name, data in iteritems(self._data):
             new_array[self._indices[set_name]] = data

--- a/setup.py
+++ b/setup.py
@@ -85,5 +85,6 @@ setup(name='openmdao',
       iproftotals=openmdao.devtools.iprofile:_prof_totals
       iprofmem=openmdao.devtools.iprof_mem:_profile_py_file
       icalltrace=openmdao.devtools.itrace:_trace_py_file
+      run_test=openmdao.devtools.run_test:run_test
       """
 )


### PR DESCRIPTION
- If none of ref, ref0, res_ref are set, we skip output scaling.
- if there is no unit conversion and ref/ref0/res_ref are not set on a connected output, we skip input scaling
- there will be a couple of follow-on PRs to this one.  One will keep scalar scalers as scalar to save memory, and the other will turn scaling vectors into scaling arrays that live alongside data in the other Vector objects in order to avoid the setup overhead of creating so many Vector objects.