### PR TITLE
removed out-of-order warning when src and target occupy the same cycle

### DIFF
--- a/openmdao/error_checking/check_config.py
+++ b/openmdao/error_checking/check_config.py
@@ -47,9 +47,10 @@ def _check_dataflow(group, logger):
     logger : object
         The object that manages logging output.
     """
+    sub2i = {sub.name: i for i, sub in enumerate(group._subsystems_allprocs)}
     graph = group.compute_sys_graph(comps_only=False)
     sccs = get_sccs_topo(graph)
-    cycles = [sorted(s) for s in sccs if len(s) > 1]
+    cycles = [sorted(s, key=lambda n: sub2i[n]) for s in sccs if len(s) > 1]
     cycle_idxs = {}
 
     if cycles:
@@ -59,6 +60,8 @@ def _check_dataflow(group, logger):
             # keep track of cycles so we can detect when a system in
             # one cycle is out of order with a system in a different cycle.
             for s in cycle:
+                if group.pathname:
+                    s = '.'.join((group.pathname, s))
                 cycle_idxs[s] = i
 
     ubcs = _get_out_of_order_subs(group, group._conn_global_abs_in2out)

--- a/openmdao/error_checking/check_config.py
+++ b/openmdao/error_checking/check_config.py
@@ -47,9 +47,9 @@ def _check_dataflow(group, logger):
     logger : object
         The object that manages logging output.
     """
-    sub2i = {sub.name: i for i, sub in enumerate(group._subsystems_allprocs)}
     graph = group.compute_sys_graph(comps_only=False)
     sccs = get_sccs_topo(graph)
+    sub2i = {sub.name: i for i, sub in enumerate(group._subsystems_allprocs)}
     cycles = [sorted(s, key=lambda n: sub2i[n]) for s in sccs if len(s) > 1]
     cycle_idxs = {}
 


### PR DESCRIPTION
- also changed cycle display order to be execution order instead of alphabetical order.